### PR TITLE
Fix/cannot migrate when first startup

### DIFF
--- a/src/authorized_keys/apps.py
+++ b/src/authorized_keys/apps.py
@@ -7,5 +7,3 @@ class AuthorizedKeysConfig(AppConfig):
 
     def ready(self):
         import authorized_keys.signals
-        # Call the update_authorized_keys_on_startup function
-        authorized_keys.signals.update_authorized_keys_on_startup()

--- a/src/authorized_keys/signals.py
+++ b/src/authorized_keys/signals.py
@@ -24,7 +24,9 @@ def update_authorized_keys_file(keys: List[str]):
     with open('/ssh/authorized_keys', 'w') as f:
         f.write(authorized_keys_content)
 
-def update_authorized_keys_on_startup():
+# Update the authorized_keys file on startup
+@receiver(post_migrate)
+def update_authorized_keys_on_startup(sender, **kwargs):
     keys = get_authorized_keys()
     update_authorized_keys_file(keys)
 


### PR DESCRIPTION

因為database還沒建立，也無table
所以會造成signal中的`update_authorized_keys_on_startup`無法query database
最終導致第一次啟動時會無法migration

這個問題只會出在第一次啟動的時候
是在github的codespace以單純環境進行測試時發現的
