### PR TITLE
Feat/add admin settings page

### DIFF
--- a/src/static/js/settings.js
+++ b/src/static/js/settings.js
@@ -74,6 +74,16 @@ function updateSetting(name, value) {
     .catch(error => console.error('Error updating setting:', error));
 }
 
+function settingsNotificationWebsocket() {
+    var socket = notificationWebsocket();
+    socket.onmessage = function (event) {
+        const data = JSON.parse(event.data);
+        console.log('Notification message:', data.message);
+        createToastAlert(data.message.details, false);
+    };
+}
+
 document.addEventListener('DOMContentLoaded', function() {
+    settingsNotificationWebsocket();
     fetchSettings();
 });

--- a/src/static/js/settings.js
+++ b/src/static/js/settings.js
@@ -1,0 +1,79 @@
+
+function fetchSettings() {
+    const accessToken = localStorage.getItem('accessToken');
+
+    fetch('/api/site/settings', {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${accessToken}`
+        },
+    })
+    .then(response => response.json())
+    .then(data => {
+        populateSettingsTable(data);
+    })
+    .catch(error => console.error('Error fetching settings:', error));
+}
+
+function populateSettingsTable(settings) {
+    const tableBody = document.getElementById('settingsTableBody');
+    tableBody.innerHTML = ''; // Clear existing table content
+
+    Object.keys(settings).forEach(key => {
+        if (typeof settings[key] === 'boolean') { // Assuming setting values are boolean
+            const row = tableBody.insertRow();
+            const nameCell = row.insertCell(0);
+            const toggleCell = row.insertCell(1);
+            nameCell.textContent = key;
+
+            // Create the label that will act as the toggle switch
+            const switchLabel = document.createElement('label');
+            switchLabel.classList.add('switch');
+
+            const toggle = document.createElement('input');
+            toggle.setAttribute('type', 'checkbox');
+            toggle.checked = settings[key];
+            toggle.addEventListener('change', () => updateSetting(key, toggle.checked));
+
+            const sliderSpan = document.createElement('span');
+            sliderSpan.classList.add('slider', 'round');
+
+            switchLabel.appendChild(toggle);
+            switchLabel.appendChild(sliderSpan);
+
+            toggleCell.appendChild(switchLabel);
+        }
+    });
+}
+
+function updateSetting(name, value) {
+
+    const accessToken = localStorage.getItem('accessToken');
+    const payload = {};
+    payload[name] = value;
+
+    fetch('/api/site/settings', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${accessToken}`
+        },
+        body: JSON.stringify(payload),
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
+        }
+        return response.json();
+    })
+    .then(data => {
+        console.log('Setting updated:', data);
+        // Optionally, refresh the settings or provide user feedback
+    })
+    .catch(error => console.error('Error updating setting:', error));
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    fetchSettings();
+});

--- a/src/static/styles/settings.css
+++ b/src/static/styles/settings.css
@@ -1,0 +1,61 @@
+/* The switch - the box around the slider */
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 60px;
+    height: 34px;
+  }
+  
+  /* The slider */
+  .switch input { 
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+  
+  .slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    -webkit-transition: .4s;
+    transition: .4s;
+  }
+  
+  .slider:before {
+    position: absolute;
+    content: "";
+    height: 26px;
+    width: 26px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    -webkit-transition: .4s;
+    transition: .4s;
+  }
+  
+  input:checked + .slider {
+    background-color: #2196F3;
+  }
+  
+  input:focus + .slider {
+    box-shadow: 0 0 1px #2196F3;
+  }
+  
+  input:checked + .slider:before {
+    -webkit-transform: translateX(26px);
+    -ms-transform: translateX(26px);
+    transform: translateX(26px);
+  }
+  
+  /* Rounded sliders */
+  .slider.round {
+    border-radius: 34px;
+  }
+  
+  .slider.round:before {
+    border-radius: 50%;
+  }

--- a/src/tunnels/templates/base.html
+++ b/src/tunnels/templates/base.html
@@ -19,6 +19,7 @@
 
    {% load static %}
    <link rel="stylesheet" href="{% static 'styles/main.css' %}">
+   {% block styles %}{% endblock %}
    <title>{% block title %}{% endblock %}</title>
 </head>
 <body>

--- a/src/tunnels/templates/navbar.html
+++ b/src/tunnels/templates/navbar.html
@@ -18,6 +18,9 @@
           </ul>
           <ul class="navbar-nav ms-auto">
               <li class="nav-item">
+                <a class="nav-link {% if request.path == '/tunnels/settings' %}active{% endif %}" aria-current="page" href="/tunnels/settings">Settings</a>
+              </li>
+              <li class="nav-item">
                   <a class="nav-link" href="#" id="logoutButton">Logout</a>
               </li>
           </ul>

--- a/src/tunnels/templates/settings.html
+++ b/src/tunnels/templates/settings.html
@@ -12,6 +12,7 @@
    <div class="d-flex justify-content-between align-items-center mb-3">
       <div class="d-flex align-items-center">
          <h2>Admin Settings</h2>
+         <div class="websocket-status status ml-2" id="websocket-status"></div>
       </div>
    </div>
 

--- a/src/tunnels/templates/settings.html
+++ b/src/tunnels/templates/settings.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+
+{% block styles %}
+{% load static %}
+<link rel="stylesheet" href="{% static 'styles/settings.css' %}">
+{% endblock %}
+
+{% block title %}Admin Settings{% endblock %}
+
+{% block content %}
+<div class="mx-5">
+   <div class="d-flex justify-content-between align-items-center mb-3">
+      <div class="d-flex align-items-center">
+         <h2>Admin Settings</h2>
+      </div>
+   </div>
+
+   <!-- Info of this section -->
+   <div class="alert-info p-1 mb-3">
+      <p>
+        <strong>INFO</strong> 
+        This section is for adjusting the settings of this server.
+    </p>
+   </div>
+   <div class="table-responsive">
+      <table class="table">
+         <thead>
+            <tr>
+               <th scope="col">Setting</th>
+               <th scope="col">Toggle</th>
+            </tr>
+         </thead>
+         <tbody id="settingsTableBody">
+         </tbody>
+      </table>
+   </div>
+</div>
+
+
+{% endblock %}
+
+{% block scripts %}
+{% load static %}
+<script src="{% static 'js/settings.js' %}"></script>
+{% endblock %}

--- a/src/tunnels/urls.py
+++ b/src/tunnels/urls.py
@@ -3,6 +3,7 @@ from tunnels.views import TunnelsIndex
 from tunnels.views import TunnelsCreate
 from tunnels.views import UserKeys
 from tunnels.views import Terminal
+from tunnels.views import AdminSettings
 from tunnels.views import SSHServerLogs
 from tunnels.views import ReverseServerAuthorizedKeysConfig
 from tunnels.views import AutoSSHTunnelScript
@@ -13,7 +14,9 @@ urlpatterns = [
     path('create', TunnelsCreate.as_view(), name='tunnels-create'),
     path('keys', UserKeys.as_view(), name='user-keys'),
     path('terminal/<int:server_id>', Terminal.as_view(), name='terminal'),
+    path('settings', AdminSettings.as_view(), name='admin-settings'),
     path('logs', SSHServerLogs.as_view(), name='ssh-server-logs'),
+
     path('server/config/<int:server_id>', ReverseServerAuthorizedKeysConfig.as_view(), name='authorized-keys-config'),
     path('server/script/autossh/<int:server_id>/<int:ssh_port>', AutoSSHTunnelScript.as_view(), name='auto-ssh-tunnel-script'),
     path('server/script/windows/<int:server_id>/<int:ssh_port>', WindowsSSHTunnelScript.as_view(), name='windows-ssh-tunnel-script'),

--- a/src/tunnels/views.py
+++ b/src/tunnels/views.py
@@ -89,6 +89,17 @@ class SSHServerLogs(APIView):
     def get(self, request):
         return render(request, 'logs.html')
 
+class AdminSettings(APIView):
+    permission_classes = (IsAdminUser,)
+    @swagger_auto_schema(
+        operation_summary="Admin Settings",
+        operation_description="Admin Settings page",
+        tags=['Page']
+    )
+    def get(self, request):
+        return render(request, 'settings.html')
+
+
 # ========================================
 # Script Views
 # ========================================


### PR DESCRIPTION
I've added a new page for adjusting settings on the Telepy Web Server.

Right now, there's only one setting available - `allow_registration`.

You can find all the settings displayed in a table format, just like the one shown below.

![image](https://github.com/NatLee/telepy/assets/10178964/0d91d55b-b181-46c8-89eb-4e3bd199b08c)

It's important to note that only the admin user can access this page and operate associated APIs.