### PR TITLE
Feat/add proxies for future frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,37 @@
 version: "3.9"
-   
+
+x-common-networks: &common-networks
+  networks:
+    - telepy-network
+
+x-common-restart: &common-restart
+  restart: always
+
 services:
+
+  traefik:
+    <<: [*common-networks, *common-restart]
+    image: traefik:v3.0
+    container_name: telepy-traefik
+    command:
+      - "--configFile=/etc/traefik/traefik.yml"
+    volumes:
+      - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./traefik/dynamic.yml:/etc/traefik/dynamic.yml:ro
+    ports:
+      - "${WEB_SERVER_PORT}:80"
+
+  frontend:
+    <<: [*common-networks, *common-restart]
+    container_name: telepy-nginx
+    image: nginx:latest
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - ./frontend:/src
+
   backend:
+    <<: [*common-networks, *common-restart]
     build:
       context: .
       dockerfile: ./Dockerfile
@@ -14,8 +44,7 @@ services:
       - WEB_SERVER_PORT=${WEB_SERVER_PORT}
       - SOCIAL_GOOGLE_CLIENT_ID=${SOCIAL_GOOGLE_CLIENT_ID}
       - SERVER_DOMAIN=${SERVER_DOMAIN}
-    ports:
-      - ${WEB_SERVER_PORT}:8000
+
     volumes: 
       - ./logs/backend:/logs
       - ./logs/ssh:/ssh-logs
@@ -29,12 +58,13 @@ services:
       - ssh
 
   redis:
+    <<: [*common-networks, *common-restart]
     image: redis:alpine
     hostname: telepy-redis
     container_name: telepy-redis
 
   ssh:
-    restart: unless-stopped
+    <<: [*common-networks, *common-restart]
     image: lscr.io/linuxserver/openssh-server
     container_name: telepy-ssh
     hostname: telepy-ssh
@@ -55,3 +85,7 @@ services:
       - ${REVERSE_SERVER_SSH_PORT}:2222 # for SSH connections, REVERSE_SERVER_SSH_PORT
     depends_on:
       - redis
+
+networks:
+  telepy-network:
+    name: telepy-network

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,4 @@
+
+<script>
+    window.location.href = '/login';
+</script>

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,14 @@
+
+server {
+    listen       80;
+    server_name  frontend;
+
+    root /src;
+
+    location / {
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+}
+

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,32 @@
+
+#user  nobody;
+worker_processes  1;
+
+#error_log  logs/error.log;
+#error_log  logs/error.log  notice;
+#error_log  logs/error.log  info;
+
+#pid        logs/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    client_max_body_size 1024M;
+
+    #keepalive_timeout  0;
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/default.conf;
+}

--- a/traefik/dynamic.yml
+++ b/traefik/dynamic.yml
@@ -1,0 +1,49 @@
+
+commonRouterSettings: &commonRouterSettings
+  entryPoints:
+    - web
+
+backendRouterSettings: &backendRouterSettings
+  <<: *commonRouterSettings
+  service: backend-service
+
+frontendServiceSettings: &frontendServiceSettings
+  loadBalancer:
+    servers:
+      - url: "http://frontend:80"
+
+backendServiceSettings: &backendServiceSettings
+  loadBalancer:
+    servers:
+      - url: "http://backend:8000"
+
+http:
+  routers:
+    frontend:
+      <<: *commonRouterSettings
+      rule: "PathPrefix(`/`)"
+      service: frontend-service
+
+    backend-api:
+      <<: *backendRouterSettings
+      rule: "PathPrefix(`/api`)"
+
+    backend-login:
+      <<: *backendRouterSettings
+      rule: "PathPrefix(`/login`)"
+
+    backend-page:
+      <<: *backendRouterSettings
+      rule: "PathPrefix(`/tunnels`)"
+
+    backend-websocket:
+      <<: *backendRouterSettings
+      rule: "PathPrefix(`/ws`)"
+
+  services:
+    frontend-service:
+      <<: *frontendServiceSettings
+
+    backend-service:
+      <<: *backendServiceSettings
+

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -1,0 +1,10 @@
+log:
+  level: DEBUG
+
+entryPoints:
+  web:
+    address: ":80"
+
+providers:
+  file:
+    filename: /etc/traefik/dynamic.yml


### PR DESCRIPTION

加入traefik做前端跟後端的proxy

前端暫用nginx去渲染頁面

日後前後端完全分離的話，可以直接無痛更換 :D
