### PR TITLE
Feat/enhance flow of creating tunnels

### DIFF
--- a/src/static/js/create.js
+++ b/src/static/js/create.js
@@ -13,6 +13,126 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 });
 
+// ============================
+// Globals moved from template
+// ============================
+let currentStep = 1;
+const totalSteps = 5;
+let currentTunnelId = null;
+let embeddedTerm = null;
+let embeddedSocket = null;
+let tunnelConnectionSocket = null;
+
+// Expose setter so other scripts can set tunnel id
+window.setCurrentTunnelId = function(id) {
+  currentTunnelId = id;
+  try { sessionStorage.setItem('currentTunnelId', String(id)); } catch (_) {}
+};
+
+function getCurrentTunnelId() {
+  if (currentTunnelId) return currentTunnelId;
+  if (window.currentTunnelId) {
+    currentTunnelId = window.currentTunnelId;
+    return currentTunnelId;
+  }
+  try {
+    const stored = sessionStorage.getItem('currentTunnelId');
+    if (stored) {
+      currentTunnelId = parseInt(stored, 10);
+      return currentTunnelId;
+    }
+  } catch (_) {}
+  return null;
+}
+
+function updateStepIndicator(step) {
+  for (let i = 1; i <= totalSteps; i++) {
+    const stepNumber = document.getElementById(`stepNumber${i}`);
+    const stepLabel = document.getElementById(`stepLabel${i}`);
+    const stepConnector = document.getElementById(`stepConnector${i}`);
+    if (stepNumber && stepLabel) {
+      stepNumber.className = 'step-number pending';
+      stepLabel.className = 'step-label';
+    }
+    if (stepConnector) {
+      stepConnector.className = 'step-connector';
+    }
+  }
+  for (let i = 1; i < step; i++) {
+    const stepNumber = document.getElementById(`stepNumber${i}`);
+    const stepLabel = document.getElementById(`stepLabel${i}`);
+    const stepConnector = document.getElementById(`stepConnector${i}`);
+    if (stepNumber && stepLabel) {
+      stepNumber.className = 'step-number completed';
+      stepNumber.innerHTML = '<i class="fas fa-check"></i>';
+      stepLabel.className = 'step-label completed';
+    }
+    if (stepConnector) {
+      stepConnector.className = 'step-connector completed';
+    }
+  }
+  const currentStepNumber = document.getElementById(`stepNumber${step}`);
+  const currentStepLabel = document.getElementById(`stepLabel${step}`);
+  if (currentStepNumber && currentStepLabel) {
+    currentStepNumber.className = 'step-number active';
+    currentStepNumber.innerHTML = String(step);
+    currentStepLabel.className = 'step-label active';
+  }
+}
+
+function showStep(step) {
+  if (currentStep === 4 && step !== 4) {
+    autoDisconnectWebSocket();
+  }
+  for (let i = 1; i <= totalSteps; i++) {
+    const section = document.getElementById(`step${i}Section`);
+    if (section) section.style.display = 'none';
+  }
+  const currentSection = document.getElementById(`step${step}Section`);
+  if (currentSection) {
+    currentSection.style.display = 'block';
+    currentSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+  currentStep = step;
+  updateStepIndicator(step);
+  if (step === 2) {
+    try { fetchUserKeys(); } catch(_) {}
+    try { fetchServiceKeys(); } catch(_) {}
+  }
+}
+
+function autoDisconnectWebSocket() {
+  if (embeddedSocket) {
+    try { embeddedSocket.close(); } catch(_) {}
+    embeddedSocket = null;
+    if (embeddedTerm) {
+      try { embeddedTerm.writeln('\x1b[33mAuto-disconnected when leaving Test Connection step.\x1b[0m'); } catch(_) {}
+    }
+  }
+  if (tunnelConnectionSocket) {
+    try { tunnelConnectionSocket.close(); } catch(_) {}
+    tunnelConnectionSocket = null;
+  }
+}
+
+function goToServerKeys() { showStep(2); }
+function goToManageUsers() {
+  showStep(3);
+  setTimeout(() => { try { loadUserList(); } catch(_) {} }, 100);
+}
+function goToTestConnection() {
+  showStep(4);
+  setTimeout(() => {
+    try { initializeStep4Configuration(); } catch(_) {}
+    try { loadAllScripts(); } catch(_) {}
+    try { initializeTunnelConnectionMonitoring(); } catch(_) {}
+  }, 100);
+}
+function goToCompletion() {
+  showStep(5);
+  setTimeout(() => { try { loadTerminalConfig(); } catch(_) {} }, 100);
+}
+
 function fetchToken() {
   const accessToken = localStorage.getItem('accessToken');
   fetch('/api/reverse/issue/token', {
@@ -46,17 +166,6 @@ function createTunnel() {
     });
     return;
   }
-
-  // Show loading indicator
-  Swal.fire({
-    title: 'Creating Tunnel...',
-    text: 'Please wait',
-    allowOutsideClick: false,
-    showConfirmButton: false,
-    willOpen: () => {
-      Swal.showLoading();
-    }
-  });
 
   const accessToken = localStorage.getItem('accessToken');
   fetch('/api/reverse/create/key/' + token, {
@@ -97,16 +206,8 @@ function createTunnel() {
       console.log('Window.currentTunnelId set to:', window.currentTunnelId);
       console.log('SessionStorage currentTunnelId:', sessionStorage.getItem('currentTunnelId'));
       
-      Swal.fire({
-        icon: 'success',
-        title: 'Tunnel Created Successfully',
-        text: `Port: ${data.port}, Reverse Port: ${data.reverse_port}`,
-        showConfirmButton: true,
-      }).then((result) => {
-        if (result.isConfirmed) {
-          showStep2();
-        }
-      });
+      // Directly proceed to next step without showing success alert
+      showStep2();
     } else {
       throw new Error('Failed to create tunnel - ' + (data.error || 'Unknown error'));
     }
@@ -124,14 +225,18 @@ function createTunnel() {
       showConfirmButton: true,
       showCancelButton: true,
       confirmButtonText: 'View Details',
-      cancelButtonText: 'Close'
+      cancelButtonText: 'Close',
+      allowOutsideClick: true,
+      allowEscapeKey: true
     }).then((result) => {
       if (result.isConfirmed) {
         Swal.fire({
           icon: 'info',
           title: 'Error Details',
           text: detailedError,
-          showConfirmButton: true
+          showConfirmButton: true,
+          allowOutsideClick: true,
+          allowEscapeKey: true
         });
       }
     });
@@ -139,10 +244,14 @@ function createTunnel() {
 }
 
 function showStep2() {
-  document.getElementById('step1Section').style.display = 'none';
-  document.getElementById('step2Section').style.display = 'block';
-  fetchUserKeys();
-  fetchServiceKeys();
+  // Use the showStep function from create.html
+  if (typeof showStep === 'function') {
+    showStep(2);
+  } else {
+    // Fallback to direct DOM manipulation
+    document.getElementById('step1Section').style.display = 'none';
+    document.getElementById('step2Section').style.display = 'block';
+  }
 }
 
 function showStep3() {
@@ -214,6 +323,122 @@ function copyKeyToClipboard() {
     });
   }).catch(err => {
     console.error('Error copying text to clipboard', err);
+  });
+}
+
+// ============================
+// Step 3: Manage Users
+// ============================
+
+function validateUsersAndProceed() {
+  const tunnelId = getCurrentTunnelId();
+  if (!tunnelId) {
+    Swal.fire({ icon: 'error', title: 'No Tunnel Selected', text: 'Please create a tunnel first' });
+    return;
+  }
+  const accessToken = localStorage.getItem('accessToken');
+  fetch(`/api/reverse/server/${tunnelId}/usernames`, {
+    method: 'GET',
+    headers: { 'Accept': 'application/json', 'Authorization': `Bearer ${accessToken}` }
+  })
+    .then(async r => { if (!r.ok) throw new Error(await r.text()); return r.json(); })
+    .then(users => {
+      if (!users || users.length === 0) {
+        Swal.fire({ icon: 'warning', title: 'No Users Added', text: 'Please add at least one user before proceeding.' });
+      } else {
+        goToTestConnection();
+      }
+    })
+    .catch(err => {
+      console.error('validateUsersAndProceed error:', err);
+      Swal.fire({ icon: 'error', title: 'Error', text: 'Failed to check users. Please try again.' });
+    });
+}
+
+function loadUserList() {
+  const tunnelId = getCurrentTunnelId();
+  if (!tunnelId) return;
+  const accessToken = localStorage.getItem('accessToken');
+  fetch(`/api/reverse/server/${tunnelId}/usernames`, {
+    method: 'GET',
+    headers: { 'Accept': 'application/json', 'Authorization': `Bearer ${accessToken}` }
+  })
+    .then(async r => { if (!r.ok) throw new Error(await r.text()); return r.json(); })
+    .then(users => {
+      const usersList = document.getElementById('usersList');
+      if (!usersList) return;
+      if (!users || users.length === 0) {
+        usersList.innerHTML = '<p class="text-muted">No users added yet.</p>';
+        return;
+      }
+      const items = users.map(u => (
+        `<div class="list-group-item d-flex justify-content-between align-items-center">
+          <span><i class=\"fas fa-user me-2\"></i>${u.username}</span>
+          <button class=\"btn btn-danger btn-sm\" onclick=\"removeUserFromTunnel(${u.id})\"><i class=\"fas fa-trash\"></i></button>
+        </div>`
+      )).join('');
+      usersList.innerHTML = `<div class="list-group">${items}</div>`;
+    })
+    .catch(err => {
+      console.error('loadUserList error:', err);
+      Swal.fire({ icon: 'error', title: 'Error', text: 'Failed to load user list' });
+    });
+}
+
+function addUserToCurrentTunnel() {
+  const usernameInput = document.getElementById('newUsername');
+  const username = (usernameInput?.value || '').trim();
+  if (!username) {
+    Swal.fire({ icon: 'warning', title: 'Username Required', text: 'Please enter a username' });
+    return;
+  }
+  const tunnelId = getCurrentTunnelId();
+  if (!tunnelId) {
+    Swal.fire({ icon: 'error', title: 'No Tunnel Selected', text: 'Please create a tunnel first' });
+    return;
+  }
+  const accessToken = localStorage.getItem('accessToken');
+  fetch('/api/reverse/server/usernames', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${accessToken}` },
+    body: JSON.stringify({ reverse_server: tunnelId, username })
+  })
+    .then(async r => { if (!r.ok) throw new Error(await r.text()); return r.json(); })
+    .then(() => {
+      if (usernameInput) usernameInput.value = '';
+      loadUserList();
+      Swal.fire({ icon: 'success', title: 'User Added', text: `User "${username}" has been added`, timer: 1200, showConfirmButton: false });
+    })
+    .catch(err => {
+      console.error('addUserToCurrentTunnel error:', err);
+      Swal.fire({ icon: 'error', title: 'Error', text: 'Failed to add user' });
+    });
+}
+
+function removeUserFromTunnel(userId) {
+  Swal.fire({
+    title: 'Remove User?',
+    text: 'Are you sure you want to remove this user?',
+    icon: 'warning',
+    showCancelButton: true,
+    confirmButtonText: 'Yes, remove',
+    cancelButtonText: 'Cancel'
+  }).then(result => {
+    if (!result.isConfirmed) return;
+    const accessToken = localStorage.getItem('accessToken');
+    fetch(`/api/reverse/server/usernames/${userId}`, {
+      method: 'DELETE',
+      headers: { 'Authorization': `Bearer ${accessToken}` }
+    })
+      .then(async r => { if (!r.ok) throw new Error(await r.text()); })
+      .then(() => {
+        loadUserList();
+        Swal.fire({ icon: 'success', title: 'User Removed', timer: 1000, showConfirmButton: false });
+      })
+      .catch(err => {
+        console.error('removeUserFromTunnel error:', err);
+        Swal.fire({ icon: 'error', title: 'Error', text: 'Failed to remove user' });
+      });
   });
 }
 
@@ -322,5 +547,336 @@ function autoFillHostFriendlyName() {
     const hostFriendlyName = document.getElementById('hostFriendlyName').value;
     document.getElementById('hostFriendlyName').value = getHostFriendlyNameFromKey(key, hostFriendlyName);
   });
+}
+
+// Add event listeners for new buttons
+document.addEventListener('DOMContentLoaded', function() {
+  // Prevent duplicate bindings
+  const alreadyBound = document.body.dataset.createBindings === '1';
+  if (alreadyBound) return;
+  document.body.dataset.createBindings = '1';
+
+  // Keys added button → go to Manage Users
+  const keysAddedBtn = document.getElementById('keysAddedBtn');
+  if (keysAddedBtn && !keysAddedBtn.dataset.bound) {
+    keysAddedBtn.dataset.bound = '1';
+    keysAddedBtn.addEventListener('click', goToManageUsers);
+  }
+
+  // Skip service key → confirm then redirect to index
+  const skipServiceKeyBtn = document.getElementById('skipServiceKeyBtn');
+  if (skipServiceKeyBtn && !skipServiceKeyBtn.dataset.bound) {
+    skipServiceKeyBtn.dataset.bound = '1';
+    skipServiceKeyBtn.addEventListener('click', function() {
+      Swal.fire({
+        title: 'Skip Service Key?',
+        text: 'Web terminal functionality will be disabled. You can add service keys later from the Keys management page.',
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonColor: '#d97706',
+        cancelButtonColor: '#6b7280',
+        confirmButtonText: 'Yes, Skip Service Key',
+        cancelButtonText: 'Cancel'
+      }).then((result) => {
+        if (result.isConfirmed) {
+          window.location.href = '/tunnels/index';
+        }
+      });
+    });
+  }
+
+  // Users configured → validate users then proceed
+  const usersConfiguredBtn = document.getElementById('usersConfiguredBtn');
+  if (usersConfiguredBtn && !usersConfiguredBtn.dataset.bound) {
+    usersConfiguredBtn.dataset.bound = '1';
+    usersConfiguredBtn.addEventListener('click', validateUsersAndProceed);
+  }
+
+  // Next step button for Step 4
+  const nextStepBtn = document.getElementById('nextStepBtn');
+  if (nextStepBtn && !nextStepBtn.dataset.bound) {
+    nextStepBtn.dataset.bound = '1';
+    nextStepBtn.addEventListener('click', goToCompletion);
+  }
+
+  // Add user button
+  const addUserToListBtn = document.getElementById('addUserToListBtn');
+  if (addUserToListBtn && !addUserToListBtn.dataset.bound) {
+    addUserToListBtn.dataset.bound = '1';
+    addUserToListBtn.addEventListener('click', addUserToCurrentTunnel);
+  }
+
+  // Terminal buttons
+  const connectTerminalBtn = document.getElementById('connectTerminalBtn');
+  if (connectTerminalBtn && !connectTerminalBtn.dataset.bound) {
+    connectTerminalBtn.dataset.bound = '1';
+    connectTerminalBtn.addEventListener('click', connectEmbeddedTerminal);
+  }
+  const disconnectTerminalBtn = document.getElementById('disconnectTerminalBtn');
+  if (disconnectTerminalBtn && !disconnectTerminalBtn.dataset.bound) {
+    disconnectTerminalBtn.dataset.bound = '1';
+    disconnectTerminalBtn.addEventListener('click', disconnectEmbeddedTerminal);
+  }
+  const clearTerminalBtn = document.getElementById('clearTerminalBtn');
+  if (clearTerminalBtn && !clearTerminalBtn.dataset.bound) {
+    clearTerminalBtn.dataset.bound = '1';
+    clearTerminalBtn.addEventListener('click', clearEmbeddedTerminal);
+  }
+
+  // Initialize step indicator
+  try { updateStepIndicator(1); } catch(_) {}
+
+  // Cleanup websocket on unload
+  window.addEventListener('beforeunload', function() {
+    if (embeddedSocket) {
+      try { embeddedSocket.close(); } catch(_) {}
+    }
+    if (tunnelConnectionSocket) {
+      try { tunnelConnectionSocket.close(); } catch(_) {}
+    }
+  });
+});
+
+// Ensure our implementations override any inline ones after page fully loads
+window.addEventListener('load', function() {
+  try {
+    window.updateStepIndicator = updateStepIndicator;
+    window.showStep = showStep;
+    window.fetchUserKeys = fetchUserKeys;
+    window.fetchServiceKeys = fetchServiceKeys;
+    window.showKeyModal = showKeyModal;
+    window.autoDisconnectWebSocket = autoDisconnectWebSocket;
+    window.goToServerKeys = goToServerKeys;
+    window.goToManageUsers = goToManageUsers;
+    window.goToTestConnection = goToTestConnection;
+    window.goToCompletion = goToCompletion;
+    window.validateUsersAndProceed = validateUsersAndProceed;
+    window.loadUserList = loadUserList;
+    window.addUserToCurrentTunnel = addUserToCurrentTunnel;
+    window.removeUserFromTunnel = removeUserFromTunnel;
+    window.initializeStep4Configuration = initializeStep4Configuration;
+    window.loadAllScripts = loadAllScripts;
+    window.loadSshScript = loadSshScript;
+    window.loadAutosshScript = loadAutosshScript;
+    window.copySshScript = copySshScript;
+    window.copyAutosshScript = copyAutosshScript;
+    window.initializeTunnelConnectionMonitoring = initializeTunnelConnectionMonitoring;
+    window.updateConnectionStatus = updateConnectionStatus;
+    window.loadTerminalConfig = loadTerminalConfig;
+    window.copyTerminalConfig = copyTerminalConfig;
+    window.copyKeyToClipboard = copyKeyToClipboard;
+  } catch (_) {}
+});
+
+
+// Enhanced script loading function
+function loadAllScripts() {
+  loadSshScript();
+  loadAutosshScript();
+}
+
+// Update existing loadAutosshScript function to use the new API
+function loadAutosshScript() {
+  const tunnelId = getCurrentTunnelId();
+  const sshPort = document.getElementById('step4SshPort').value;
+  const keyPath = document.getElementById('sshKeyPath').value;
+  
+  const accessToken = localStorage.getItem('accessToken');
+  let url = `/tunnels/server/script/autossh/${tunnelId}/${sshPort}`;
+  if (keyPath) {
+    url += `?key_path=${encodeURIComponent(keyPath)}`;
+  }
+  
+  fetch(url, {
+    method: 'GET',
+    headers: {
+      'Accept': 'application/json',
+      'Authorization': `Bearer ${accessToken}`,
+    },
+  })
+  .then(response => response.json())
+  .then(data => {
+    document.getElementById('autosshScript').textContent = data.script;
+    if (Prism && Prism.highlight) {
+      Prism.highlightElement(document.getElementById('autosshScript'));
+    }
+  })
+  .catch(error => {
+    console.error('Error loading AutoSSH script:', error);
+    document.getElementById('autosshScript').textContent = 'Error loading script';
+  });
+}
+
+// Update existing loadSshScript function
+function loadSshScript() {
+  const tunnelId = getCurrentTunnelId();
+  const sshPort = document.getElementById('step4SshPort').value;
+  const keyPath = document.getElementById('sshKeyPath').value;
+  
+  const accessToken = localStorage.getItem('accessToken');
+  let url = `/tunnels/server/script/ssh/${tunnelId}/${sshPort}`;
+  if (keyPath) {
+    url += `?key_path=${encodeURIComponent(keyPath)}`;
+  }
+  
+  fetch(url, {
+    method: 'GET',
+    headers: {
+      'Accept': 'application/json',
+      'Authorization': `Bearer ${accessToken}`,
+    },
+  })
+  .then(response => response.json())
+  .then(data => {
+    document.getElementById('sshScript').textContent = data.script;
+    if (Prism && Prism.highlight) {
+      Prism.highlightElement(document.getElementById('sshScript'));
+    }
+  })
+  .catch(error => {
+    console.error('Error loading SSH script:', error);
+    document.getElementById('sshScript').textContent = 'Error loading script';
+  });
+}
+
+// Add event listeners for script configuration changes
+document.addEventListener('DOMContentLoaded', function() {
+  const sshPortInput = document.getElementById('step4SshPort');
+  const keyPathInput = document.getElementById('sshKeyPath');
+  
+  if (sshPortInput) {
+    sshPortInput.addEventListener('input', debounce(loadAllScripts, 500));
+  }
+  
+  if (keyPathInput) {
+    keyPathInput.addEventListener('input', debounce(loadAllScripts, 500));
+  }
+});
+
+// ============================
+// Tunnel Connection Monitoring
+// ============================
+
+function initializeTunnelConnectionMonitoring() {
+  const tunnelId = getCurrentTunnelId();
+  if (!tunnelId) {
+    console.error('No tunnel ID available for connection monitoring');
+    return;
+  }
+
+  // Initialize connection status
+  updateConnectionStatus('disconnected', 'Waiting for Connection...', 
+    'Run the script on your target server to establish the tunnel connection.');
+
+  // Setup WebSocket connection
+  setupTunnelConnectionWebSocket(tunnelId);
+}
+
+function setupTunnelConnectionWebSocket(tunnelId) {
+  if (tunnelConnectionSocket) {
+    tunnelConnectionSocket.close();
+  }
+
+  const ws_scheme = window.location.protocol === "https:" ? "wss" : "ws";
+  const ws_path = `${ws_scheme}://${window.location.host}/ws/tunnel_connection/${tunnelId}/`;
+  const accessToken = localStorage.getItem('accessToken') || '';
+
+  // Subprotocols: token.<base64(jwt)>, tunnel.<id>, auth.<ticket>
+  const tokenInfo = `token.${btoa(accessToken)}`;
+  const tunnelInfo = `tunnel.${tunnelId}`;
+  let ticket = sha256(`${tunnelId}.connection`);
+  ticket = `auth.${ticket}`;
+
+  tunnelConnectionSocket = new WebSocket(ws_path, [tokenInfo, tunnelInfo, ticket]);
+
+  tunnelConnectionSocket.onopen = function() {
+    console.log('Tunnel connection WebSocket connected');
+    updateConnectionStatus('connecting', 'Checking Connection...', 
+      'Monitoring tunnel connection status...');
+  };
+
+  tunnelConnectionSocket.onmessage = function(event) {
+    try {
+      const data = JSON.parse(event.data);
+      console.log('Tunnel connection message:', data);
+      
+      if (data.type === 'connection_status') {
+        const isConnected = data.is_connected;
+        
+        if (isConnected) {
+          updateConnectionStatus('connected', 'Connection Successful!', 
+            `Tunnel "${data.host_friendly_name}" is now connected via port ${data.reverse_port}.`);
+        } else {
+          updateConnectionStatus('disconnected', 'Waiting for Connection...', 
+            'Run the script on your target server to establish the tunnel connection.');
+        }
+      } else if (data.type === 'error') {
+        console.error('Tunnel connection error:', data.message);
+        updateConnectionStatus('disconnected', 'Connection Check Failed', 
+          'Unable to verify connection status. Please check manually.');
+      }
+    } catch (error) {
+      console.error('Error parsing tunnel connection message:', error);
+    }
+  };
+
+  tunnelConnectionSocket.onclose = function(event) {
+    console.log('Tunnel connection WebSocket closed:', event);
+    
+    // Only show disconnect status if we're still on step 4
+    if (currentStep === 4) {
+      updateConnectionStatus('disconnected', 'Connection Monitoring Stopped', 
+        'WebSocket connection closed. Status updates are no longer available.');
+    }
+    
+    // Auto-reconnect after 3 seconds if still on step 4
+    if (currentStep === 4) {
+      setTimeout(() => {
+        if (currentStep === 4 && !tunnelConnectionSocket) {
+          console.log('Attempting to reconnect tunnel connection WebSocket...');
+          setupTunnelConnectionWebSocket(tunnelId);
+        }
+      }, 3000);
+    }
+  };
+
+  tunnelConnectionSocket.onerror = function(error) {
+    console.error('Tunnel connection WebSocket error:', error);
+    updateConnectionStatus('disconnected', 'Connection Monitor Error', 
+      'Unable to monitor connection status. Please check your configuration.');
+  };
+}
+
+function updateConnectionStatus(status, title, message) {
+  const badgeElement = document.getElementById('connectionStatusBadge');
+  const titleElement = document.getElementById('connectionStatusText');
+  const detailElement = document.getElementById('connectionStatusDetail');
+  
+  if (!badgeElement || !titleElement || !detailElement) {
+    console.warn('Connection status elements not found');
+    return;
+  }
+
+  // Update badge status
+  badgeElement.className = `tunnel-status ${status}`;
+  
+  // Update text content
+  titleElement.textContent = title;
+  detailElement.textContent = message;
+  
+  // Update text colors based on status
+  titleElement.className = 'fw-bold mb-2';
+  switch (status) {
+    case 'connected':
+      titleElement.classList.add('text-success');
+      break;
+    case 'connecting':
+      titleElement.classList.add('text-warning');
+      break;
+    case 'disconnected':
+    default:
+      titleElement.classList.add('text-muted');
+      break;
+  }
 }
 

--- a/src/static/js/tunnels.js
+++ b/src/static/js/tunnels.js
@@ -478,6 +478,7 @@ async function fetchSSHScript(url) {
 async function updateServerScriptContent(serverId) {
     try {
         const sshPort = document.getElementById('sshPort').value;
+        const sshKeyPath = document.getElementById('sshKeyPathTunnels').value.trim();
 
         if (!sshPort) {
             console.error('SSH port is empty');
@@ -489,13 +490,30 @@ async function updateServerScriptContent(serverId) {
             return;
         }
 
-        // Fetch the SSH script
-        const sshScriptData = await fetchSSHScript(`/tunnels/server/script/autossh/${serverId}/${sshPort}`);
+        // Build URLs with optional key path parameter
+        let sshUrl = `/tunnels/server/script/ssh/${serverId}/${sshPort}`;
+        let autosshUrl = `/tunnels/server/script/autossh/${serverId}/${sshPort}`;
+        let autosshServiceUrl = `/tunnels/server/script/autossh-service/${serverId}/${sshPort}`;
+        let powershellUrl = `/tunnels/server/script/powershell/${serverId}/${sshPort}`;
+        
+        if (sshKeyPath) {
+            const keyPathParam = `?key_path=${encodeURIComponent(sshKeyPath)}`;
+            sshUrl += keyPathParam;
+            autosshUrl += keyPathParam;
+            autosshServiceUrl += keyPathParam;
+            powershellUrl += keyPathParam;
+        }
+
+        // Fetch the SSH Simple script
+        const sshSimpleScriptData = await fetchSSHScript(sshUrl);
+
+        // Fetch the AutoSSH script
+        const autosshScriptData = await fetchSSHScript(autosshUrl);
 
         // If service script is not available, it means the user have not add usernames to this server
         let sshServiceScriptData = {};
         try {
-            sshServiceScriptData = await fetchSSHScript(`/tunnels/server/script/autossh-service/${serverId}/${sshPort}`);
+            sshServiceScriptData = await fetchSSHScript(autosshServiceUrl);
         } catch (error) {
             console.error('Error fetching SSH service script:', error);
             sshServiceScriptData = {
@@ -505,11 +523,12 @@ async function updateServerScriptContent(serverId) {
         }
 
         // Fetch the PowerShell script
-        const powershellScriptData = await fetchSSHScript(`/tunnels/server/script/powershell/${serverId}/${sshPort}`);
+        const powershellScriptData = await fetchSSHScript(powershellUrl);
 
         // Check if Prism is available and highlight the code
-        if (Prism && Prism.highlight && sshScriptData.script && sshServiceScriptData.script && powershellScriptData.script) {
-            document.getElementById('tunnelCommandSSH').innerHTML = Prism.highlight(sshScriptData.script, Prism.languages[sshScriptData.language], sshScriptData.language);
+        if (Prism && Prism.highlight && sshSimpleScriptData.script && autosshScriptData.script && sshServiceScriptData.script && powershellScriptData.script) {
+            document.getElementById('tunnelCommandSSHSimple').innerHTML = Prism.highlight(sshSimpleScriptData.script, Prism.languages[sshSimpleScriptData.language], sshSimpleScriptData.language);
+            document.getElementById('tunnelCommandAutoSSH').innerHTML = Prism.highlight(autosshScriptData.script, Prism.languages[autosshScriptData.language], autosshScriptData.language);
             document.getElementById('tunnelCommandSSHService').innerHTML = Prism.highlight(sshServiceScriptData.script, Prism.languages[sshServiceScriptData.language], sshServiceScriptData.language);
 
             document.getElementById('tunnelCommandSSHServiceSteps').innerHTML = Prism.highlight(
@@ -530,10 +549,27 @@ function showServerScriptModal(serverId) {
     // Show the modal after updating its content
     const modal = new bootstrap.Modal(document.getElementById('serverScriptModal'));
     modal.show();
-    // Re-fetch script content when SSH port changes and update the modal content
+    
+    // Re-fetch script content when SSH port or key path changes and update the modal content
     document.getElementById('sshPort').onchange = async () => {
-        // Close the old modal
         await updateServerScriptContent(serverId);
+    };
+    
+    document.getElementById('sshKeyPathTunnels').oninput = debounce(async () => {
+        await updateServerScriptContent(serverId);
+    }, 500);
+}
+
+// Debounce function for input events
+function debounce(func, wait) {
+    let timeout;
+    return function executedFunction(...args) {
+        const later = () => {
+            clearTimeout(timeout);
+            func(...args);
+        };
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
     };
 }
 

--- a/src/tunnels/routing.py
+++ b/src/tunnels/routing.py
@@ -6,5 +6,6 @@ websocket_urlpatterns = [
     re_path(r'ws/notifications/$', consumers.NotificationConsumer.as_asgi()),
     re_path(r'ws/terminal/$', consumers.TerminalConsumer.as_asgi()),
     re_path(r'ws/filemanager/$', consumers.FileManagerConsumer.as_asgi()),
+    re_path(r'ws/tunnel_connection/(?P<tunnel_id>\d+)/$', consumers.TunnelConnectionConsumer.as_asgi()),
 ]
 

--- a/src/tunnels/templates/base.html
+++ b/src/tunnels/templates/base.html
@@ -16,6 +16,8 @@
    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/prism.min.js"></script>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/components/prism-bash.min.js"></script>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/components/prism-powershell.min.js"></script>
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/components/prism-yaml.min.js"></script>
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/components/prism-yml.min.js"></script>
    
    <!-- Include Poppins font -->
    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/src/tunnels/templates/create.html
+++ b/src/tunnels/templates/create.html
@@ -12,6 +12,75 @@
   border-radius: 8px !important;
   border: 1px solid #4a5568 !important;
 }
+
+/* Connection Status Light Styles */
+.connection-light {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  position: relative;
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+  transition: all 0.3s ease;
+}
+
+.connection-light.disconnected {
+  background: linear-gradient(135deg, #ef4444, #dc2626);
+  animation: pulse-red 2s infinite;
+}
+
+.connection-light.connected {
+  background: linear-gradient(135deg, #10b981, #059669);
+  animation: pulse-green 2s infinite;
+}
+
+.connection-light.connecting {
+  background: linear-gradient(135deg, #f59e0b, #d97706);
+  animation: pulse-yellow 1s infinite;
+}
+
+.connection-light::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 20px;
+  height: 20px;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 50%;
+  transition: all 0.3s ease;
+}
+
+.connection-light.connected::before {
+  box-shadow: 0 0 15px rgba(255, 255, 255, 0.8);
+}
+
+@keyframes pulse-red {
+  0%, 100% { 
+    box-shadow: 0 8px 25px rgba(239, 68, 68, 0.4), 0 0 20px rgba(239, 68, 68, 0.3);
+  }
+  50% { 
+    box-shadow: 0 8px 25px rgba(239, 68, 68, 0.6), 0 0 30px rgba(239, 68, 68, 0.5);
+  }
+}
+
+@keyframes pulse-green {
+  0%, 100% { 
+    box-shadow: 0 8px 25px rgba(16, 185, 129, 0.4), 0 0 20px rgba(16, 185, 129, 0.3);
+  }
+  50% { 
+    box-shadow: 0 8px 25px rgba(16, 185, 129, 0.6), 0 0 30px rgba(16, 185, 129, 0.5);
+  }
+}
+
+@keyframes pulse-yellow {
+  0%, 100% { 
+    box-shadow: 0 8px 25px rgba(245, 158, 11, 0.4), 0 0 20px rgba(245, 158, 11, 0.3);
+  }
+  50% { 
+    box-shadow: 0 8px 25px rgba(245, 158, 11, 0.6), 0 0 30px rgba(245, 158, 11, 0.5);
+  }
+}
 </style>
 {% endblock %}
 
@@ -97,14 +166,16 @@
             </div>
             
             <div class="mb-4">
-              <label for="key" class="form-label">SSH Public Key</label>
-              <textarea class="form-control" id="key" rows="3" placeholder="Paste your public SSH key here"></textarea>
-              <small class="form-text text-muted">This is required to create the tunnel.</small>
+              <label for="key" class="form-label">Target Server SSH Public Key</label>
+              <textarea class="form-control" id="key" rows="3" placeholder="Paste your target server's public SSH key here"></textarea>
+              <small class="form-text text-muted">This is the public key of the server you want to connect to. Telepy will use this key to authenticate with your target server.</small>
               <div id="keyFeedback" class="invalid-feedback mt-2"></div>
             </div>
             
             <div class="mb-4">
-              <label for="sshPort" class="form-label">SSH Port</label>
+              <label for="sshPort" class="form-label">
+                <i class="fas fa-network-wired me-2"></i>SSH Port
+              </label>
               <input type="number" class="form-control" id="sshPort" value="22" min="1" max="65535">
               <small class="form-text text-muted">Enter your server's SSH port. Default is 22.</small>
             </div>
@@ -171,10 +242,22 @@
               <div id="serviceKeys" class="mt-2"></div>
             </div>
           </div>
-          <div class="d-grid mt-4">
+          <div class="d-grid gap-2 mt-4">
             <button class="btn btn-custom" id="keysAddedBtn">
               <i class="fas fa-check me-2"></i>Keys Added, Continue
             </button>
+            <button class="btn btn-outline-warning" id="skipServiceKeyBtn" type="button">
+              <i class="fas fa-exclamation-triangle me-2"></i>Skip Service Key (Web Terminal Disabled)
+            </button>
+          </div>
+          <div class="alert alert-warning border-0 mt-3" style="background: linear-gradient(135deg, rgba(245, 158, 11, 0.1), rgba(217, 119, 6, 0.1)); border-radius: 12px;">
+            <div class="d-flex align-items-start">
+              <i class="fas fa-info-circle text-warning me-3 mt-1"></i>
+              <div>
+                <h6 class="fw-bold mb-2">About Service Keys</h6>
+                <p class="mb-0 small">Service keys are required for web terminal functionality. If you skip adding them now, you can add them later from the Keys management page, but web terminal will be disabled until then.</p>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -193,12 +276,12 @@
           </div>
         </div>
         <div class="card-body p-4">
-          <div class="alert alert-warning">
+          <div class="alert alert-info border-0" style="background: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(16, 185, 129, 0.1)); border-radius: 12px;">
             <div class="d-flex align-items-start">
-              <i class="fas fa-exclamation-triangle text-warning me-3 mt-1"></i>
+              <i class="fas fa-info-circle text-primary me-3 mt-1"></i>
               <div>
-                <h6 class="fw-bold mb-2">User Management</h6>
-                <p class="mb-0 small">Add users who will have access to this tunnel on the target machine.</p>
+                <h6 class="fw-bold mb-2">Target Server Users</h6>
+                <p class="mb-0 small">Add users who exist on your <strong>target server</strong> (the machine you want to connect to). These are the actual user accounts on that server that will be able to access the tunnel.</p>
               </div>
             </div>
           </div>
@@ -206,9 +289,6 @@
           <div id="userManagementSection">
             <div class="d-flex justify-content-between align-items-center mb-3">
               <h6 class="fw-bold mb-0">Current Users</h6>
-              <button class="btn btn-outline-primary btn-sm" id="addUserBtn">
-                <i class="fas fa-plus me-2"></i>Add User
-              </button>
             </div>
             <div id="usersList" class="mb-4">
               <!-- User list will be populated here -->
@@ -246,12 +326,22 @@
           </div>
         </div>
         <div class="card-body p-4">
-          <div class="alert alert-success border-0" style="background: linear-gradient(135deg, rgba(16, 185, 129, 0.1), rgba(5, 150, 105, 0.1)); border-radius: 12px;">
+          <div class="alert alert-info border-0" style="background: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(16, 185, 129, 0.1)); border-radius: 12px;">
             <div class="d-flex align-items-start">
-              <i class="fas fa-check-circle text-success me-3 mt-1"></i>
+              <i class="fas fa-info-circle text-primary me-3 mt-1"></i>
               <div>
-                <h6 class="fw-bold mb-2">Test Your Connection</h6>
-                <p class="mb-0 small">Run the AutoSSH script on your target server to establish the tunnel connection.</p>
+                <h6 class="fw-bold mb-2">Important: Server-Side Script</h6>
+                <p class="mb-0 small">The scripts below are for your <strong>target server</strong> (the machine you want to connect to). You need to run one of these scripts on that server to establish the reverse tunnel connection to Telepy.</p>
+              </div>
+            </div>
+          </div>
+          
+          <div class="alert alert-warning border-0" style="background: linear-gradient(135deg, rgba(245, 158, 11, 0.1), rgba(217, 119, 6, 0.1)); border-radius: 12px;">
+            <div class="d-flex align-items-start">
+              <i class="fas fa-exclamation-triangle text-warning me-3 mt-1"></i>
+              <div>
+                <h6 class="fw-bold mb-2">SSH Key Setup Required</h6>
+                <p class="mb-0 small">Before running the script, make sure you've added the Telepy public key to your server's <code>~/.ssh/authorized_keys</code> file (from Step 2). This allows Telepy to connect to your server.</p>
               </div>
             </div>
           </div>
@@ -310,6 +400,7 @@
                   <i class="fas fa-sync-alt me-2"></i>AutoSSH
                 </button>
               </li>
+
             </ul>
             
             <div class="tab-content" id="scriptTypeTabContent">
@@ -329,44 +420,44 @@
                   </button>
                 </div>
               </div>
+
             </div>
           </div>
           
-          <!-- Embedded Terminal Section -->
+          <!-- Connection Status Section -->
           <div class="mb-4">
-            <h6 class="fw-bold mb-3">Terminal Console</h6>
-            <p class="text-muted small mb-3">Use this terminal to test the connection after running the script:</p>
-            <div class="border rounded" style="height: 300px; background-color: #000;">
-              <div id="embeddedTerminal" style="height: 100%; padding: 10px;"></div>
+            <h6 class="fw-bold mb-3">Connection Status</h6>
+            <p class="text-muted small mb-3">The system will automatically detect when your server connects using the script above:</p>
+            
+            <!-- Connection Status Indicator -->
+            <div class="card border-0 shadow-sm" style="border-radius: 12px; background: linear-gradient(135deg, rgba(59, 130, 246, 0.05), rgba(16, 185, 129, 0.05));">
+              <div class="card-body p-4 text-center">
+                <div class="d-flex justify-content-center align-items-center gap-3 mb-2">
+                  <span id="connectionStatusBadge" class="tunnel-status disconnected"></span>
+                  <h5 id="connectionStatusText" class="fw-bold mb-0 text-muted">Waiting for Connection...</h5>
+                </div>
+                <p id="connectionStatusDetail" class="text-muted mb-0 small">
+                  Run the script on your target server to establish the tunnel connection.
+                </p>
+              </div>
             </div>
-            <div class="d-flex gap-2 mt-3">
-              <button class="btn btn-success btn-sm" id="connectTerminalBtn">
-                <i class="fas fa-plug me-2"></i>Connect Terminal
-              </button>
-              <button class="btn btn-outline-warning btn-sm" id="disconnectTerminalBtn">
-                <i class="fas fa-unplug me-2"></i>Disconnect
-              </button>
-              <button class="btn btn-outline-secondary btn-sm" id="clearTerminalBtn">
-                <i class="fas fa-eraser me-2"></i>Clear
-              </button>
+            
+            <!-- Status Messages -->
+            <div class="alert alert-info border-0 mt-3" id="statusHelpMessage" style="background: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(16, 185, 129, 0.1)); border-radius: 12px;">
+              <div class="d-flex align-items-start">
+                <i class="fas fa-info-circle text-primary me-3 mt-1"></i>
+                <div>
+                  <h6 class="fw-bold mb-2">Testing Not Required</h6>
+                  <p class="mb-0 small">If you prefer not to test the connection now, you can proceed to complete the setup. You can always test the connection later using the scripts available on the main tunnels page.</p>
+                </div>
+              </div>
             </div>
           </div>
           
-          <div class="row">
-            <div class="col-md-6">
-              <div class="d-grid">
-                <button class="btn btn-outline-danger" id="testFailedBtn">
-                  <i class="fas fa-times me-2"></i>Connection Failed
-                </button>
-              </div>
-            </div>
-            <div class="col-md-6">
-              <div class="d-grid">
-                <button class="btn btn-custom" id="testSuccessBtn">
-                  <i class="fas fa-check me-2"></i>Connection Successful
-                </button>
-              </div>
-            </div>
+          <div class="d-grid">
+            <button class="btn btn-custom" id="nextStepBtn">
+              <i class="fas fa-arrow-right me-2"></i>Next
+            </button>
           </div>
         </div>
       </div>
@@ -445,1005 +536,4 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
 <script src="{% static 'js/create.js' %}"></script>
-<script>
-// Step Management Functions
-let currentStep = 1;
-const totalSteps = 5;
-
-function updateStepIndicator(step) {
-  // Reset all steps
-  for (let i = 1; i <= totalSteps; i++) {
-    const stepNumber = document.getElementById(`stepNumber${i}`);
-    const stepLabel = document.getElementById(`stepLabel${i}`);
-    const stepConnector = document.getElementById(`stepConnector${i}`);
-    
-    if (stepNumber && stepLabel) {
-      stepNumber.className = 'step-number pending';
-      stepLabel.className = 'step-label';
-    }
-    
-    if (stepConnector) {
-      stepConnector.className = 'step-connector';
-    }
-  }
-  
-  // Update completed steps
-  for (let i = 1; i < step; i++) {
-    const stepNumber = document.getElementById(`stepNumber${i}`);
-    const stepLabel = document.getElementById(`stepLabel${i}`);
-    const stepConnector = document.getElementById(`stepConnector${i}`);
-    
-    if (stepNumber && stepLabel) {
-      stepNumber.className = 'step-number completed';
-      stepNumber.innerHTML = '<i class="fas fa-check"></i>';
-      stepLabel.className = 'step-label completed';
-    }
-    
-    if (stepConnector) {
-      stepConnector.className = 'step-connector completed';
-    }
-  }
-  
-  // Update current step
-  const currentStepNumber = document.getElementById(`stepNumber${step}`);
-  const currentStepLabel = document.getElementById(`stepLabel${step}`);
-  if (currentStepNumber && currentStepLabel) {
-    currentStepNumber.className = 'step-number active';
-    currentStepNumber.innerHTML = step;
-    currentStepLabel.className = 'step-label active';
-  }
-}
-
-function showStep(step) {
-  // Auto-disconnect websocket when leaving step 4
-  if (currentStep === 4 && step !== 4) {
-    autoDisconnectWebSocket();
-  }
-  
-  // Hide all steps
-  for (let i = 1; i <= totalSteps; i++) {
-    const stepSection = document.getElementById(`step${i}Section`);
-    if (stepSection) {
-      stepSection.style.display = 'none';
-    }
-  }
-  
-  // Show current step
-  const currentStepSection = document.getElementById(`step${step}Section`);
-  if (currentStepSection) {
-    currentStepSection.style.display = 'block';
-    currentStepSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  }
-  
-  currentStep = step;
-  updateStepIndicator(step);
-}
-
-// Function to auto-disconnect websocket when leaving test connection step
-function autoDisconnectWebSocket() {
-  if (embeddedSocket) {
-    console.log('Auto-disconnecting WebSocket when leaving Test Connection step');
-    embeddedSocket.close();
-    embeddedSocket = null;
-    if (embeddedTerm) {
-      embeddedTerm.writeln('\x1b[33mAuto-disconnected when leaving Test Connection step.\x1b[0m');
-    }
-  }
-}
-
-// Enhanced navigation functions
-function goToServerKeys() {
-  showStep(2);
-}
-
-function goToManageUsers() {
-  showStep(3);
-  // Small delay to ensure tunnel ID is available
-  setTimeout(() => {
-    console.log('goToManageUsers - checking tunnel ID...');
-    const tunnelId = getCurrentTunnelId();
-    if (tunnelId) {
-      console.log('Tunnel ID available, loading user list...');
-      loadUserList();
-    } else {
-      console.warn('No tunnel ID available yet in goToManageUsers');
-    }
-  }, 100);
-}
-
-function goToTestConnection() {
-  showStep(4);
-  // Small delay to ensure tunnel ID is available
-  setTimeout(() => {
-    console.log('goToTestConnection - checking tunnel ID...');
-    const tunnelId = getCurrentTunnelId();
-    if (tunnelId) {
-      console.log('Tunnel ID available, loading scripts and initializing terminal...');
-      initializeStep4Configuration();
-      loadSshScript();
-      loadAutosshScript();
-      initializeEmbeddedTerminal();
-    } else {
-      console.warn('No tunnel ID available yet in goToTestConnection');
-    }
-  }, 100);
-}
-
-function goToCompletion() {
-  showStep(5);
-  // Small delay to ensure tunnel ID is available
-  setTimeout(() => {
-    console.log('goToCompletion - checking tunnel ID...');
-    const tunnelId = getCurrentTunnelId();
-    if (tunnelId) {
-      console.log('Tunnel ID available, loading terminal config...');
-      loadTerminalConfig();
-    } else {
-      console.warn('No tunnel ID available yet in goToCompletion');
-    }
-  }, 100);
-}
-
-// Event listeners for new buttons
-document.addEventListener('DOMContentLoaded', function() {
-  // Update existing create tunnel button
-  const createTunnelBtn = document.getElementById('createTunnelBtn');
-  if (createTunnelBtn) {
-    createTunnelBtn.addEventListener('click', function(e) {
-      e.preventDefault();
-      // Validate form first
-      const hostFriendlyName = document.getElementById('hostFriendlyName').value;
-      const key = document.getElementById('key').value;
-      const sshPort = document.getElementById('sshPort').value;
-      
-      if (!hostFriendlyName || !key || !isValidSSHKey(key) || !isValidPort(sshPort)) {
-        Swal.fire({
-          icon: 'error',
-          title: 'Invalid Input',
-          text: 'Please check your inputs and try again.',
-          showConfirmButton: true,
-        });
-        return;
-      }
-      
-      // If validation passes, create tunnel (it will automatically go to next step)
-      createTunnel();
-    });
-  }
-  
-  // Keys added button
-  const keysAddedBtn = document.getElementById('keysAddedBtn');
-  if (keysAddedBtn) {
-    keysAddedBtn.addEventListener('click', goToManageUsers);
-  }
-  
-  // Users configured button
-  const usersConfiguredBtn = document.getElementById('usersConfiguredBtn');
-  if (usersConfiguredBtn) {
-    usersConfiguredBtn.addEventListener('click', validateUsersAndProceed);
-  }
-  
-  // Test success button
-  const testSuccessBtn = document.getElementById('testSuccessBtn');
-  if (testSuccessBtn) {
-    testSuccessBtn.addEventListener('click', goToCompletion);
-  }
-  
-  // Test failed button
-  const testFailedBtn = document.getElementById('testFailedBtn');
-  if (testFailedBtn) {
-    testFailedBtn.addEventListener('click', function() {
-      Swal.fire({
-        icon: 'error',
-        title: 'Connection Failed',
-        text: 'Please check your configuration and try again.',
-        showConfirmButton: true,
-      });
-    });
-  }
-  
-  // Note: openTerminalBtn has been removed in favor of embedded terminal
-  
-  // Create another tunnel button
-  const createAnotherBtn = document.getElementById('createAnotherBtn');
-  if (createAnotherBtn) {
-    createAnotherBtn.addEventListener('click', function() {
-      window.location.reload();
-    });
-  }
-  
-  // Initialize step indicator
-  updateStepIndicator(1);
-  
-  // User management event listeners
-  const addUserToListBtn = document.getElementById('addUserToListBtn');
-  if (addUserToListBtn) {
-    addUserToListBtn.addEventListener('click', addUserToCurrentTunnel);
-  }
-  
-  // Terminal button event listeners
-  const connectTerminalBtn = document.getElementById('connectTerminalBtn');
-  if (connectTerminalBtn) {
-    connectTerminalBtn.addEventListener('click', connectEmbeddedTerminal);
-  }
-  
-  const disconnectTerminalBtn = document.getElementById('disconnectTerminalBtn');
-  if (disconnectTerminalBtn) {
-    disconnectTerminalBtn.addEventListener('click', disconnectEmbeddedTerminal);
-  }
-  
-  const clearTerminalBtn = document.getElementById('clearTerminalBtn');
-  if (clearTerminalBtn) {
-    clearTerminalBtn.addEventListener('click', clearEmbeddedTerminal);
-  }
-  
-  // Auto-cleanup websocket on page unload
-  window.addEventListener('beforeunload', function() {
-    if (embeddedSocket) {
-      embeddedSocket.close();
-    }
-  });
-});
-
-// Global variables for tunnel management
-let currentTunnelId = null;
-let embeddedTerm = null;
-let embeddedSocket = null;
-
-// Function to set current tunnel ID from create.js
-window.setCurrentTunnelId = function(id) {
-  currentTunnelId = id;
-  console.log('Current tunnel ID set to:', id);
-  
-  // Store in session storage for persistence
-  sessionStorage.setItem('currentTunnelId', id);
-};
-
-// Function to get current tunnel ID with fallback
-function getCurrentTunnelId() {
-  console.log('getCurrentTunnelId called - checking sources...');
-  console.log('currentTunnelId variable:', currentTunnelId);
-  console.log('window.currentTunnelId:', window.currentTunnelId);
-  console.log('sessionStorage currentTunnelId:', sessionStorage.getItem('currentTunnelId'));
-  
-  // First try the global variable
-  if (currentTunnelId) {
-    console.log('Using currentTunnelId variable:', currentTunnelId);
-    return currentTunnelId;
-  }
-  
-  // Then try window.currentTunnelId
-  if (window.currentTunnelId) {
-    currentTunnelId = window.currentTunnelId;
-    console.log('Using window.currentTunnelId:', currentTunnelId);
-    return currentTunnelId;
-  }
-  
-  // Finally try session storage
-  const storedId = sessionStorage.getItem('currentTunnelId');
-  if (storedId) {
-    currentTunnelId = parseInt(storedId);
-    console.log('Using sessionStorage currentTunnelId:', currentTunnelId);
-    return currentTunnelId;
-  }
-  
-  console.warn('No tunnel ID found in any source');
-  return null;
-}
-
-// Override existing step functions to use new step system
-function showStep2() {
-  goToServerKeys();
-  // Keep the original functionality
-  fetchUserKeys();
-  fetchServiceKeys();
-}
-
-function showStep3() {
-  goToCompletion();
-}
-
-// ============================
-// User Management Functions
-// ============================
-
-function validateUsersAndProceed() {
-  const tunnelId = getCurrentTunnelId();
-  if (!tunnelId) {
-    Swal.fire({
-      icon: 'error',
-      title: 'No Tunnel Selected',
-      text: 'Please create a tunnel first',
-      showConfirmButton: true,
-    });
-    return;
-  }
-  
-  const accessToken = localStorage.getItem('accessToken');
-  fetch(`/api/reverse/server/${tunnelId}/usernames`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${accessToken}`
-    }
-  })
-  .then(response => response.json())
-  .then(users => {
-    if (users.length === 0) {
-      Swal.fire({
-        icon: 'warning',
-        title: 'No Users Added',
-        text: 'Please add at least one user before proceeding to test connection.',
-        showConfirmButton: true,
-        confirmButtonText: 'OK'
-      });
-    } else {
-      // At least one user exists, proceed to test connection
-      goToTestConnection();
-    }
-  })
-  .catch(error => {
-    console.error('Error checking users:', error);
-    Swal.fire({
-      icon: 'error',
-      title: 'Error',
-      text: 'Failed to check users. Please try again.',
-      showConfirmButton: true,
-    });
-  });
-}
-
-function loadUserList() {
-  const tunnelId = getCurrentTunnelId();
-  if (!tunnelId) {
-    console.warn('No tunnel ID available for loading user list');
-    return;
-  }
-  
-  console.log('Loading user list for tunnel ID:', tunnelId);
-  const accessToken = localStorage.getItem('accessToken');
-  fetch(`/api/reverse/server/${tunnelId}/usernames`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${accessToken}`
-    }
-  })
-  .then(response => response.json())
-  .then(users => {
-    const usersList = document.getElementById('usersList');
-    if (users.length === 0) {
-      usersList.innerHTML = '<p class="text-muted">No users added yet.</p>';
-    } else {
-      let usersHtml = '<div class="list-group">';
-      users.forEach(user => {
-        usersHtml += `
-          <div class="list-group-item d-flex justify-content-between align-items-center">
-            <span><i class="fas fa-user me-2"></i>${user.username}</span>
-            <button class="btn btn-danger btn-sm" onclick="removeUserFromTunnel(${user.id})">
-              <i class="fas fa-trash"></i>
-            </button>
-          </div>
-        `;
-      });
-      usersHtml += '</div>';
-      usersList.innerHTML = usersHtml;
-    }
-  })
-  .catch(error => {
-    console.error('Error loading user list:', error);
-    Swal.fire({
-      icon: 'error',
-      title: 'Error',
-      text: 'Failed to load user list',
-      showConfirmButton: true,
-    });
-  });
-}
-
-function addUserToCurrentTunnel() {
-  const username = document.getElementById('newUsername').value.trim();
-  if (!username) {
-    Swal.fire({
-      icon: 'warning',
-      title: 'Username Required',
-      text: 'Please enter a username',
-      showConfirmButton: true,
-    });
-    return;
-  }
-  
-  const tunnelId = getCurrentTunnelId();
-  if (!tunnelId) {
-    Swal.fire({
-      icon: 'error',
-      title: 'No Tunnel Selected',
-      text: 'Please create a tunnel first',
-      showConfirmButton: true,
-    });
-    return;
-  }
-  
-  console.log('Adding user to tunnel ID:', tunnelId);
-  const accessToken = localStorage.getItem('accessToken');
-  fetch('/api/reverse/server/usernames', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${accessToken}`
-    },
-    body: JSON.stringify({
-      reverse_server: tunnelId,
-      username: username
-    })
-  })
-  .then(response => {
-    if (response.ok) {
-      document.getElementById('newUsername').value = '';
-      loadUserList();
-      Swal.fire({
-        icon: 'success',
-        title: 'User Added',
-        text: `User "${username}" has been added successfully`,
-        showConfirmButton: false,
-        timer: 1500
-      });
-    } else {
-      return response.json().then(data => {
-        throw new Error(data.message || 'Failed to add user');
-      });
-    }
-  })
-  .catch(error => {
-    console.error('Error adding user:', error);
-    Swal.fire({
-      icon: 'error',
-      title: 'Error',
-      text: error.message || 'Failed to add user',
-      showConfirmButton: true,
-    });
-  });
-}
-
-function removeUserFromTunnel(userId) {
-  Swal.fire({
-    title: 'Remove User?',
-    text: 'Are you sure you want to remove this user?',
-    icon: 'warning',
-    showCancelButton: true,
-    confirmButtonText: 'Yes, remove',
-    cancelButtonText: 'Cancel'
-  }).then((result) => {
-    if (result.isConfirmed) {
-      const accessToken = localStorage.getItem('accessToken');
-      fetch(`/api/reverse/server/usernames/${userId}`, {
-        method: 'DELETE',
-        headers: {
-          'Authorization': `Bearer ${accessToken}`
-        }
-      })
-      .then(response => {
-        if (response.ok) {
-          loadUserList();
-          Swal.fire({
-            icon: 'success',
-            title: 'User Removed',
-            text: 'User has been removed successfully',
-            showConfirmButton: false,
-            timer: 1500
-          });
-        } else {
-          throw new Error('Failed to remove user');
-        }
-      })
-      .catch(error => {
-        console.error('Error removing user:', error);
-        Swal.fire({
-          icon: 'error',
-          title: 'Error',
-          text: 'Failed to remove user',
-          showConfirmButton: true,
-        });
-      });
-    }
-  });
-}
-
-// ============================
-// Step 4 Configuration Functions
-// ============================
-
-function initializeStep4Configuration() {
-  // Copy SSH port from step 1 to step 4
-  const step1SshPort = document.getElementById('sshPort').value || '22';
-  const step4SshPort = document.getElementById('step4SshPort');
-  if (step4SshPort) {
-    step4SshPort.value = step1SshPort;
-  }
-  
-  // Add event listeners for dynamic script updates and validation
-  const step4SshPortElement = document.getElementById('step4SshPort');
-  const sshKeyPathElement = document.getElementById('sshKeyPath');
-  
-  if (step4SshPortElement) {
-    // Add port validation
-    step4SshPortElement.addEventListener('input', function() {
-      step4SshPortElement.value = step4SshPortElement.value.trim();
-      if (isValidPort(step4SshPortElement.value)) {
-        step4SshPortElement.classList.remove('is-invalid');
-        step4SshPortElement.classList.add('is-valid');
-      } else {
-        step4SshPortElement.classList.remove('is-valid');
-        step4SshPortElement.classList.add('is-invalid');
-      }
-      // Update script after validation
-      debounceScriptUpdate();
-    });
-  }
-  
-  if (sshKeyPathElement) {
-    // Add key path validation (basic path validation)
-    sshKeyPathElement.addEventListener('input', function() {
-      const keyPath = sshKeyPathElement.value.trim();
-      sshKeyPathElement.classList.remove('is-invalid', 'is-valid');
-      
-      if (keyPath === '') {
-        // Empty is valid (will use default)
-        sshKeyPathElement.classList.add('is-valid');
-      } else if (isValidKeyPath(keyPath)) {
-        sshKeyPathElement.classList.add('is-valid');
-      } else {
-        sshKeyPathElement.classList.add('is-invalid');
-      }
-      // Update script after validation
-      debounceScriptUpdate();
-    });
-  }
-}
-
-// Basic key path validation function
-function isValidKeyPath(path) {
-  if (!path) return true; // Empty path is valid
-  
-  // Basic path validation - should start with / or ~ or .
-  // and not contain dangerous characters
-  const pathRegex = /^[~\/.][a-zA-Z0-9_\-/.~]*$/;
-  return pathRegex.test(path) && path.length < 256;
-}
-
-// Debounced script update function
-const debounceScriptUpdate = debounce(function() {
-  console.log('Script configuration changed, updating...');
-  loadSshScript();
-  loadAutosshScript();
-}, 500);
-
-// ============================
-// AutoSSH Script Functions
-// ============================
-
-function loadSshScript() {
-  const tunnelId = getCurrentTunnelId();
-  if (!tunnelId) {
-    console.warn('No tunnel ID available for loading SSH script');
-    document.getElementById('sshScript').textContent = 'Please create a tunnel first.';
-    return;
-  }
-  
-  // Get SSH port from step 4 (or fallback to step 1)
-  const step4SshPort = document.getElementById('step4SshPort');
-  const step1SshPort = document.getElementById('sshPort');
-  const sshPort = (step4SshPort && step4SshPort.value) ? step4SshPort.value : (step1SshPort ? step1SshPort.value : '22');
-  
-  // Get custom SSH key path if specified
-  const sshKeyPathElement = document.getElementById('sshKeyPath');
-  const sshKeyPath = sshKeyPathElement ? sshKeyPathElement.value.trim() : '';
-  
-  const accessToken = localStorage.getItem('accessToken');
-  
-  console.log('Loading SSH script for tunnel ID:', tunnelId, 'SSH port:', sshPort, 'Key path:', sshKeyPath);
-  
-  // Build the API URL with optional key path parameter
-  let apiUrl = `/tunnels/server/script/ssh/${tunnelId}/${sshPort}`;
-  if (sshKeyPath) {
-    apiUrl += `?key_path=${encodeURIComponent(sshKeyPath)}`;
-  }
-  
-  fetch(apiUrl, {
-    method: 'GET',
-    headers: {
-      'Authorization': `Bearer ${accessToken}`
-    }
-  })
-  .then(response => response.json())
-  .then(data => {
-    const scriptElement = document.getElementById('sshScript');
-    scriptElement.textContent = data.script;
-    
-    // Apply syntax highlighting
-    if (typeof Prism !== 'undefined') {
-      Prism.highlightElement(scriptElement);
-    }
-  })
-  .catch(error => {
-    console.error('Error loading SSH script:', error);
-    document.getElementById('sshScript').textContent = 'Error loading script. Please try again.';
-  });
-}
-
-function loadAutosshScript() {
-  const tunnelId = getCurrentTunnelId();
-  if (!tunnelId) {
-    console.warn('No tunnel ID available for loading autossh script');
-    document.getElementById('autosshScript').textContent = 'Please create a tunnel first.';
-    return;
-  }
-  
-  // Get SSH port from step 4 (or fallback to step 1)
-  const step4SshPort = document.getElementById('step4SshPort');
-  const step1SshPort = document.getElementById('sshPort');
-  const sshPort = (step4SshPort && step4SshPort.value) ? step4SshPort.value : (step1SshPort ? step1SshPort.value : '22');
-  
-  // Get custom SSH key path if specified
-  const sshKeyPathElement = document.getElementById('sshKeyPath');
-  const sshKeyPath = sshKeyPathElement ? sshKeyPathElement.value.trim() : '';
-  
-  const accessToken = localStorage.getItem('accessToken');
-  
-  console.log('Loading autossh script for tunnel ID:', tunnelId, 'SSH port:', sshPort, 'Key path:', sshKeyPath);
-  
-  // Build the API URL with optional key path parameter
-  let apiUrl = `/tunnels/server/script/autossh/${tunnelId}/${sshPort}`;
-  if (sshKeyPath) {
-    apiUrl += `?key_path=${encodeURIComponent(sshKeyPath)}`;
-  }
-  
-  fetch(apiUrl, {
-    method: 'GET',
-    headers: {
-      'Authorization': `Bearer ${accessToken}`
-    }
-  })
-  .then(response => response.json())
-  .then(data => {
-    const scriptElement = document.getElementById('autosshScript');
-    if (data.script) {
-      scriptElement.textContent = data.script;
-    } else {
-      // Fallback: generate script client-side if server doesn't support key_path param
-      generateAutosshScriptClientSide(data.script, sshKeyPath);
-    }
-    
-    // Apply syntax highlighting
-    if (typeof Prism !== 'undefined') {
-      Prism.highlightElement(scriptElement);
-    }
-  })
-  .catch(error => {
-    console.error('Error loading autossh script:', error);
-    document.getElementById('autosshScript').textContent = 'Error loading script. Please try again.';
-  });
-}
-
-function generateAutosshScriptClientSide(originalScript, sshKeyPath) {
-  const scriptElement = document.getElementById('autosshScript');
-  let script = originalScript;
-  
-  if (sshKeyPath && script) {
-    // Add SSH key parameter to the autossh command
-    // Look for autossh command and add -i flag
-    script = script.replace(
-      /autossh\s+([^-\s])/g, 
-      `autossh -i ${sshKeyPath} $1`
-    );
-    
-    // Also add to any ssh commands
-    script = script.replace(
-      /ssh\s+([^-\s])/g,
-      `ssh -i ${sshKeyPath} $1`
-    );
-  }
-  
-  scriptElement.textContent = script;
-}
-
-function copySshScript() {
-  const scriptText = document.getElementById('sshScript').textContent;
-  navigator.clipboard.writeText(scriptText).then(() => {
-    Swal.fire({
-      icon: 'success',
-      title: 'Script Copied!',
-      text: 'SSH script has been copied to clipboard',
-      showConfirmButton: false,
-      timer: 1500
-    });
-  }).catch(err => {
-    console.error('Error copying script:', err);
-    Swal.fire({
-      icon: 'error',
-      title: 'Copy Failed',
-      text: 'Failed to copy script to clipboard',
-      showConfirmButton: true,
-    });
-  });
-}
-
-function copyAutosshScript() {
-  const scriptText = document.getElementById('autosshScript').textContent;
-  navigator.clipboard.writeText(scriptText).then(() => {
-    Swal.fire({
-      icon: 'success',
-      title: 'Script Copied!',
-      text: 'AutoSSH script has been copied to clipboard',
-      showConfirmButton: false,
-      timer: 1500
-    });
-  }).catch(err => {
-    console.error('Error copying script:', err);
-    Swal.fire({
-      icon: 'error',
-      title: 'Copy Failed',
-      text: 'Failed to copy script to clipboard',
-      showConfirmButton: true,
-    });
-  });
-}
-
-// ============================
-// Embedded Terminal Functions
-// ============================
-
-function initializeEmbeddedTerminal() {
-  const terminalContainer = document.getElementById('embeddedTerminal');
-  
-  if (embeddedTerm) {
-    try {
-      embeddedTerm.dispose();
-    } catch (e) {
-      console.log('Terminal dispose error (ignored):', e);
-    }
-  }
-  
-  // Clear container
-  terminalContainer.innerHTML = '';
-  
-  Terminal.applyAddon(fit);
-  embeddedTerm = new Terminal({
-    cursorBlink: true,
-    fontSize: 12,
-    fontFamily: 'Menlo, Monaco, "Courier New", monospace',
-    theme: {
-      background: '#000000',
-      foreground: '#ffffff'
-    }
-  });
-  
-  embeddedTerm.open(terminalContainer);
-  embeddedTerm.fit();
-  embeddedTerm.writeln('Welcome to the embedded terminal!');
-  embeddedTerm.writeln('Click "Connect Terminal" to establish a connection.');
-  embeddedTerm.writeln('');
-}
-
-function connectEmbeddedTerminal() {
-  const tunnelId = getCurrentTunnelId();
-  if (!tunnelId) {
-    Swal.fire({
-      icon: 'error',
-      title: 'No Tunnel',
-      text: 'Please create a tunnel first',
-      showConfirmButton: true,
-    });
-    return;
-  }
-  
-  console.log('Connecting terminal for tunnel ID:', tunnelId);
-  // First get the list of usernames for this tunnel
-  const accessToken = localStorage.getItem('accessToken');
-  fetch(`/api/reverse/server/${tunnelId}/usernames`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${accessToken}`
-    }
-  })
-  .then(response => response.json())
-  .then(users => {
-    if (users.length === 0) {
-      Swal.fire({
-        icon: 'warning',
-        title: 'No Users',
-        text: 'Please add at least one user before connecting',
-        showConfirmButton: true,
-      });
-      return;
-    }
-    
-    // Show username selection
-    const usernameOptions = {};
-    users.forEach(user => {
-      usernameOptions[user.username] = user.username;
-    });
-    
-    Swal.fire({
-      title: 'Select Username',
-      input: 'select',
-      inputOptions: usernameOptions,
-      inputPlaceholder: 'Choose a username',
-      showCancelButton: true,
-    }).then((result) => {
-      if (result.isConfirmed && result.value) {
-        establishTerminalConnection(result.value);
-      }
-    });
-  })
-  .catch(error => {
-    console.error('Error fetching users:', error);
-    Swal.fire({
-      icon: 'error',
-      title: 'Error',
-      text: 'Failed to fetch users',
-      showConfirmButton: true,
-    });
-  });
-}
-
-function establishTerminalConnection(username) {
-  if (embeddedSocket) {
-    embeddedSocket.close();
-  }
-  
-  const tunnelId = getCurrentTunnelId();
-  if (!tunnelId) {
-    embeddedTerm.writeln('\x1b[31mError: No tunnel ID available\x1b[0m');
-    return;
-  }
-  
-  // Recreate terminal to avoid double event listeners
-  const terminalContainer = document.getElementById('embeddedTerminal');
-  terminalContainer.innerHTML = '';
-  
-  if (embeddedTerm) {
-    try {
-      embeddedTerm.dispose();
-    } catch (e) {
-      console.log('Terminal dispose error (ignored):', e);
-    }
-  }
-  
-  // Recreate terminal
-  Terminal.applyAddon(fit);
-  embeddedTerm = new Terminal({
-    cursorBlink: true,
-    fontSize: 12,
-    fontFamily: 'Menlo, Monaco, "Courier New", monospace',
-    theme: {
-      background: '#000000',
-      foreground: '#ffffff'
-    }
-  });
-  
-  embeddedTerm.open(terminalContainer);
-  embeddedTerm.fit();
-  
-  const ws_scheme = window.location.protocol === "https:" ? "wss" : "ws";
-  const accessToken = localStorage.getItem('accessToken');
-  const ws_path = `${ws_scheme}://${window.location.host}/ws/terminal/`;
-  
-  const tokenInfo = `token.${btoa(accessToken)}`;
-  const serverInfo = `server.${tunnelId}`;
-  const usernameInfo = `username.${username}`;
-  let ticket = sha256(`${tunnelId}.${username}`);
-  ticket = `auth.${ticket}`;
-  
-  console.log('Establishing terminal connection for tunnel ID:', tunnelId, 'username:', username);
-  embeddedSocket = new WebSocket(ws_path, [tokenInfo, serverInfo, usernameInfo, ticket]);
-  
-  embeddedSocket.onopen = function() {
-    embeddedTerm.clear();
-    embeddedTerm.writeln('\x1b[32mConnection established!\x1b[0m');
-    embeddedTerm.writeln('You can now test your tunnel connection.');
-    embeddedTerm.writeln('');
-  };
-  
-  embeddedSocket.onmessage = function(event) {
-    embeddedTerm.write(event.data);
-  };
-  
-  embeddedSocket.onclose = function() {
-    embeddedTerm.writeln('\x1b[31mConnection closed.\x1b[0m');
-  };
-  
-  embeddedSocket.onerror = function(error) {
-    embeddedTerm.writeln('\x1b[31mConnection error occurred.\x1b[0m');
-  };
-  
-  // Add terminal key event handler only once
-  embeddedTerm.on('key', (key, ev) => {
-    const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
-    const ctrlKey = isMac ? ev.metaKey : ev.ctrlKey;
-
-    // Handle copy operation
-    if (ctrlKey && key === 'c' && embeddedTerm.hasSelection()) {
-      navigator.clipboard.writeText(embeddedTerm.getSelection());
-    } else {
-      // Send key to server only if socket is open
-      if (embeddedSocket && embeddedSocket.readyState === WebSocket.OPEN) {
-        embeddedSocket.send(JSON.stringify({ action: "pty_input", payload: { input: key } }));
-      }
-    }
-  });
-  
-  embeddedTerm.on('paste', (data) => {
-    if (embeddedSocket && embeddedSocket.readyState === WebSocket.OPEN) {
-      embeddedSocket.send(JSON.stringify({ action: "pty_input", payload: { input: data } }));
-    }
-  });
-}
-
-function disconnectEmbeddedTerminal() {
-  if (embeddedSocket) {
-    embeddedSocket.close();
-    embeddedSocket = null;
-    embeddedTerm.writeln('\x1b[33mDisconnected by user.\x1b[0m');
-  }
-}
-
-function clearEmbeddedTerminal() {
-  if (embeddedTerm) {
-    embeddedTerm.clear();
-  }
-}
-
-// ============================
-// Terminal Config Functions
-// ============================
-
-function loadTerminalConfig() {
-  const tunnelId = getCurrentTunnelId();
-  if (!tunnelId) {
-    console.warn('No tunnel ID available for loading terminal config');
-    document.getElementById('terminalConfig').textContent = 'Please create a tunnel first.';
-    return;
-  }
-  
-  console.log('Loading terminal config for tunnel ID:', tunnelId);
-  const accessToken = localStorage.getItem('accessToken');
-  fetch(`/tunnels/server/config/${tunnelId}`, {
-    method: 'GET',
-    headers: {
-      'Authorization': `Bearer ${accessToken}`
-    }
-  })
-  .then(response => response.json())
-  .then(data => {
-    document.getElementById('terminalConfig').textContent = data.config;
-  })
-  .catch(error => {
-    console.error('Error loading terminal config:', error);
-    document.getElementById('terminalConfig').textContent = 'Error loading configuration. Please try again.';
-  });
-}
-
-function copyTerminalConfig() {
-  const configText = document.getElementById('terminalConfig').textContent;
-  navigator.clipboard.writeText(configText).then(() => {
-    Swal.fire({
-      icon: 'success',
-      title: 'Configuration Copied!',
-      text: 'Terminal configuration has been copied to clipboard',
-      showConfirmButton: false,
-      timer: 1500
-    });
-  }).catch(err => {
-    console.error('Error copying configuration:', err);
-    Swal.fire({
-      icon: 'error',
-      title: 'Copy Failed',
-      text: 'Failed to copy configuration to clipboard',
-      showConfirmButton: true,
-    });
-  });
-}
-</script>
 {% endblock %}

--- a/src/tunnels/templates/create.html
+++ b/src/tunnels/templates/create.html
@@ -256,15 +256,79 @@
             </div>
           </div>
           
-          <!-- AutoSSH Script Section -->
+          <!-- Script Configuration Section -->
           <div class="mb-4">
-            <h6 class="fw-bold mb-3">AutoSSH Connection Script</h6>
+            <h6 class="fw-bold mb-3">Script Configuration</h6>
+            <p class="text-muted small mb-3">Verify and adjust the connection parameters before generating the script:</p>
+            
+            <div class="row g-3 mb-3">
+              <div class="col-md-6">
+                <label for="step4SshPort" class="form-label">
+                  <i class="fas fa-network-wired me-2 text-primary"></i>SSH Port
+                </label>
+                <input type="number" class="form-control" id="step4SshPort" value="22" min="1" max="65535">
+                <small class="form-text text-muted">Confirm your server's SSH port (default: 22)</small>
+              </div>
+              <div class="col-md-6">
+                <label for="sshKeyPath" class="form-label">
+                  <i class="fas fa-key me-2 text-warning"></i>SSH Key Path (Optional)
+                </label>
+                <input type="text" class="form-control" id="sshKeyPath" placeholder="e.g., ~/.ssh/id_rsa">
+                <small class="form-text text-muted">Specify custom SSH key location if needed</small>
+              </div>
+            </div>
+            
+            <div class="alert alert-info border-0 mb-3" style="background: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(16, 185, 129, 0.1)); border-radius: 12px;">
+              <div class="d-flex align-items-start">
+                <i class="fas fa-info-circle text-primary me-3 mt-1"></i>
+                <div>
+                  <h6 class="fw-bold mb-2">Configuration Tips</h6>
+                  <ul class="mb-0 small">
+                    <li><strong>SSH Port:</strong> Most servers use port 22. Check your server configuration if unsure.</li>
+                    <li><strong>SSH Key:</strong> Leave blank to use default key (~/.ssh/id_rsa). Specify path for custom keys.</li>
+                    <li><strong>Script Update:</strong> The script will automatically update when you change these values.</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+          
+          <!-- Connection Script Section -->
+          <div class="mb-4">
+            <h6 class="fw-bold mb-3">Connection Script</h6>
             <p class="text-muted small mb-3">Execute this script on your target server to create the tunnel:</p>
-            <div class="position-relative">
-              <pre id="autosshScript" class="form-control language-bash" style="height: 150px; font-family: 'Courier New', monospace; background-color: #2d3748; color: #e2e8f0; padding: 15px;" readonly>Loading script...</pre>
-              <button class="btn btn-outline-secondary btn-sm position-absolute top-0 end-0 m-2" onclick="copyAutosshScript()">
-                <i class="fas fa-copy me-1"></i>Copy
-              </button>
+            
+            <!-- Script Type Tabs -->
+            <ul class="nav nav-tabs mb-3" id="scriptTypeTab" role="tablist" style="border: none;">
+              <li class="nav-item" role="presentation">
+                <button class="tab-link active" id="sshTab" data-bs-toggle="tab" data-bs-target="#sshContent" type="button" role="tab" aria-controls="ssh" aria-selected="true">
+                  <i class="fas fa-terminal me-2"></i>SSH
+                </button>
+              </li>
+              <li class="nav-item" role="presentation">
+                <button class="tab-link" id="autosshTab" data-bs-toggle="tab" data-bs-target="#autosshContent" type="button" role="tab" aria-controls="autossh" aria-selected="false">
+                  <i class="fas fa-sync-alt me-2"></i>AutoSSH
+                </button>
+              </li>
+            </ul>
+            
+            <div class="tab-content" id="scriptTypeTabContent">
+              <div class="tab-pane fade show active" id="sshContent" role="tabpanel" aria-labelledby="ssh-tab">
+                <div class="position-relative">
+                  <pre id="sshScript" class="form-control language-bash" style="height: 150px; font-family: 'Courier New', monospace; background-color: #2d3748; color: #e2e8f0; padding: 15px;" readonly>Loading SSH script...</pre>
+                  <button class="btn btn-outline-secondary btn-sm position-absolute top-0 end-0 m-2" onclick="copySshScript()">
+                    <i class="fas fa-copy me-1"></i>Copy
+                  </button>
+                </div>
+              </div>
+              <div class="tab-pane fade" id="autosshContent" role="tabpanel" aria-labelledby="autossh-tab">
+                <div class="position-relative">
+                  <pre id="autosshScript" class="form-control language-bash" style="height: 150px; font-family: 'Courier New', monospace; background-color: #2d3748; color: #e2e8f0; padding: 15px;" readonly>Loading AutoSSH script...</pre>
+                  <button class="btn btn-outline-secondary btn-sm position-absolute top-0 end-0 m-2" onclick="copyAutosshScript()">
+                    <i class="fas fa-copy me-1"></i>Copy
+                  </button>
+                </div>
+              </div>
             </div>
           </div>
           
@@ -494,7 +558,9 @@ function goToTestConnection() {
     console.log('goToTestConnection - checking tunnel ID...');
     const tunnelId = getCurrentTunnelId();
     if (tunnelId) {
-      console.log('Tunnel ID available, loading autossh script and initializing terminal...');
+      console.log('Tunnel ID available, loading scripts and initializing terminal...');
+      initializeStep4Configuration();
+      loadSshScript();
       loadAutosshScript();
       initializeEmbeddedTerminal();
     } else {
@@ -884,8 +950,126 @@ function removeUserFromTunnel(userId) {
 }
 
 // ============================
+// Step 4 Configuration Functions
+// ============================
+
+function initializeStep4Configuration() {
+  // Copy SSH port from step 1 to step 4
+  const step1SshPort = document.getElementById('sshPort').value || '22';
+  const step4SshPort = document.getElementById('step4SshPort');
+  if (step4SshPort) {
+    step4SshPort.value = step1SshPort;
+  }
+  
+  // Add event listeners for dynamic script updates and validation
+  const step4SshPortElement = document.getElementById('step4SshPort');
+  const sshKeyPathElement = document.getElementById('sshKeyPath');
+  
+  if (step4SshPortElement) {
+    // Add port validation
+    step4SshPortElement.addEventListener('input', function() {
+      step4SshPortElement.value = step4SshPortElement.value.trim();
+      if (isValidPort(step4SshPortElement.value)) {
+        step4SshPortElement.classList.remove('is-invalid');
+        step4SshPortElement.classList.add('is-valid');
+      } else {
+        step4SshPortElement.classList.remove('is-valid');
+        step4SshPortElement.classList.add('is-invalid');
+      }
+      // Update script after validation
+      debounceScriptUpdate();
+    });
+  }
+  
+  if (sshKeyPathElement) {
+    // Add key path validation (basic path validation)
+    sshKeyPathElement.addEventListener('input', function() {
+      const keyPath = sshKeyPathElement.value.trim();
+      sshKeyPathElement.classList.remove('is-invalid', 'is-valid');
+      
+      if (keyPath === '') {
+        // Empty is valid (will use default)
+        sshKeyPathElement.classList.add('is-valid');
+      } else if (isValidKeyPath(keyPath)) {
+        sshKeyPathElement.classList.add('is-valid');
+      } else {
+        sshKeyPathElement.classList.add('is-invalid');
+      }
+      // Update script after validation
+      debounceScriptUpdate();
+    });
+  }
+}
+
+// Basic key path validation function
+function isValidKeyPath(path) {
+  if (!path) return true; // Empty path is valid
+  
+  // Basic path validation - should start with / or ~ or .
+  // and not contain dangerous characters
+  const pathRegex = /^[~\/.][a-zA-Z0-9_\-/.~]*$/;
+  return pathRegex.test(path) && path.length < 256;
+}
+
+// Debounced script update function
+const debounceScriptUpdate = debounce(function() {
+  console.log('Script configuration changed, updating...');
+  loadSshScript();
+  loadAutosshScript();
+}, 500);
+
+// ============================
 // AutoSSH Script Functions
 // ============================
+
+function loadSshScript() {
+  const tunnelId = getCurrentTunnelId();
+  if (!tunnelId) {
+    console.warn('No tunnel ID available for loading SSH script');
+    document.getElementById('sshScript').textContent = 'Please create a tunnel first.';
+    return;
+  }
+  
+  // Get SSH port from step 4 (or fallback to step 1)
+  const step4SshPort = document.getElementById('step4SshPort');
+  const step1SshPort = document.getElementById('sshPort');
+  const sshPort = (step4SshPort && step4SshPort.value) ? step4SshPort.value : (step1SshPort ? step1SshPort.value : '22');
+  
+  // Get custom SSH key path if specified
+  const sshKeyPathElement = document.getElementById('sshKeyPath');
+  const sshKeyPath = sshKeyPathElement ? sshKeyPathElement.value.trim() : '';
+  
+  const accessToken = localStorage.getItem('accessToken');
+  
+  console.log('Loading SSH script for tunnel ID:', tunnelId, 'SSH port:', sshPort, 'Key path:', sshKeyPath);
+  
+  // Build the API URL with optional key path parameter
+  let apiUrl = `/tunnels/server/script/ssh/${tunnelId}/${sshPort}`;
+  if (sshKeyPath) {
+    apiUrl += `?key_path=${encodeURIComponent(sshKeyPath)}`;
+  }
+  
+  fetch(apiUrl, {
+    method: 'GET',
+    headers: {
+      'Authorization': `Bearer ${accessToken}`
+    }
+  })
+  .then(response => response.json())
+  .then(data => {
+    const scriptElement = document.getElementById('sshScript');
+    scriptElement.textContent = data.script;
+    
+    // Apply syntax highlighting
+    if (typeof Prism !== 'undefined') {
+      Prism.highlightElement(scriptElement);
+    }
+  })
+  .catch(error => {
+    console.error('Error loading SSH script:', error);
+    document.getElementById('sshScript').textContent = 'Error loading script. Please try again.';
+  });
+}
 
 function loadAutosshScript() {
   const tunnelId = getCurrentTunnelId();
@@ -895,11 +1079,26 @@ function loadAutosshScript() {
     return;
   }
   
-  const sshPort = document.getElementById('sshPort').value || '22';
+  // Get SSH port from step 4 (or fallback to step 1)
+  const step4SshPort = document.getElementById('step4SshPort');
+  const step1SshPort = document.getElementById('sshPort');
+  const sshPort = (step4SshPort && step4SshPort.value) ? step4SshPort.value : (step1SshPort ? step1SshPort.value : '22');
+  
+  // Get custom SSH key path if specified
+  const sshKeyPathElement = document.getElementById('sshKeyPath');
+  const sshKeyPath = sshKeyPathElement ? sshKeyPathElement.value.trim() : '';
+  
   const accessToken = localStorage.getItem('accessToken');
   
-  console.log('Loading autossh script for tunnel ID:', tunnelId);
-  fetch(`/tunnels/server/script/autossh/${tunnelId}/${sshPort}`, {
+  console.log('Loading autossh script for tunnel ID:', tunnelId, 'SSH port:', sshPort, 'Key path:', sshKeyPath);
+  
+  // Build the API URL with optional key path parameter
+  let apiUrl = `/tunnels/server/script/autossh/${tunnelId}/${sshPort}`;
+  if (sshKeyPath) {
+    apiUrl += `?key_path=${encodeURIComponent(sshKeyPath)}`;
+  }
+  
+  fetch(apiUrl, {
     method: 'GET',
     headers: {
       'Authorization': `Bearer ${accessToken}`
@@ -908,7 +1107,12 @@ function loadAutosshScript() {
   .then(response => response.json())
   .then(data => {
     const scriptElement = document.getElementById('autosshScript');
-    scriptElement.textContent = data.script;
+    if (data.script) {
+      scriptElement.textContent = data.script;
+    } else {
+      // Fallback: generate script client-side if server doesn't support key_path param
+      generateAutosshScriptClientSide(data.script, sshKeyPath);
+    }
     
     // Apply syntax highlighting
     if (typeof Prism !== 'undefined') {
@@ -918,6 +1122,49 @@ function loadAutosshScript() {
   .catch(error => {
     console.error('Error loading autossh script:', error);
     document.getElementById('autosshScript').textContent = 'Error loading script. Please try again.';
+  });
+}
+
+function generateAutosshScriptClientSide(originalScript, sshKeyPath) {
+  const scriptElement = document.getElementById('autosshScript');
+  let script = originalScript;
+  
+  if (sshKeyPath && script) {
+    // Add SSH key parameter to the autossh command
+    // Look for autossh command and add -i flag
+    script = script.replace(
+      /autossh\s+([^-\s])/g, 
+      `autossh -i ${sshKeyPath} $1`
+    );
+    
+    // Also add to any ssh commands
+    script = script.replace(
+      /ssh\s+([^-\s])/g,
+      `ssh -i ${sshKeyPath} $1`
+    );
+  }
+  
+  scriptElement.textContent = script;
+}
+
+function copySshScript() {
+  const scriptText = document.getElementById('sshScript').textContent;
+  navigator.clipboard.writeText(scriptText).then(() => {
+    Swal.fire({
+      icon: 'success',
+      title: 'Script Copied!',
+      text: 'SSH script has been copied to clipboard',
+      showConfirmButton: false,
+      timer: 1500
+    });
+  }).catch(err => {
+    console.error('Error copying script:', err);
+    Swal.fire({
+      icon: 'error',
+      title: 'Copy Failed',
+      text: 'Failed to copy script to clipboard',
+      showConfirmButton: true,
+    });
   });
 }
 

--- a/src/tunnels/templates/tunnels.html
+++ b/src/tunnels/templates/tunnels.html
@@ -116,7 +116,9 @@
        <div class="modal-body">
          <!-- SSH port -->
          <div class="input-group mb-3">
-            <span class="input-group-text" id="basic-addon1">Target Server SSH Port</span>
+            <span class="input-group-text" id="basic-addon1">
+               <i class="fas fa-network-wired me-2"></i>Target Server SSH Port
+            </span>
             <input type="text" class="form-control" id="sshPort" placeholder="Enter SSH Port" value="22" data-toggle="tooltip" data-placement="right" title="Invalid Port Number">
          </div>
          
@@ -140,19 +142,29 @@
          <!-- Nav tabs -->
          <ul class="nav nav-tabs" id="osTab">
            <li class="nav-item">
-             <button class="tab-link active" id="ssh-simple-tab" data-bs-toggle="tab" data-bs-target="#ssh-simple" aria-controls="ssh-simple" aria-selected="true">SSH</button>
+             <button class="tab-link active" id="ssh-simple-tab" data-bs-toggle="tab" data-bs-target="#ssh-simple" aria-controls="ssh-simple" aria-selected="true">
+               <i class="fas fa-terminal me-2"></i>SSH
+             </button>
            </li>
            <li class="nav-item">
-             <button class="tab-link" id="autossh-tab" data-bs-toggle="tab" data-bs-target="#autossh" aria-controls="autossh" aria-selected="false">AutoSSH</button>
+             <button class="tab-link" id="autossh-tab" data-bs-toggle="tab" data-bs-target="#autossh" aria-controls="autossh" aria-selected="false">
+               <i class="fas fa-sync-alt me-2"></i>AutoSSH
+             </button>
            </li>
            <li class="nav-item">
-            <button class="tab-link" id="ssh-service-tab" data-bs-toggle="tab" data-bs-target="#ssh-service" aria-controls="ssh-service" aria-selected="false">SSH Service</button>
+            <button class="tab-link" id="ssh-service-tab" data-bs-toggle="tab" data-bs-target="#ssh-service" aria-controls="ssh-service" aria-selected="false">
+              <i class="fas fa-server me-2"></i>SSH Service
+            </button>
            </li>
            <li class="nav-item">
-             <button class="tab-link" id="powershell-tab" data-bs-toggle="tab" data-bs-target="#powershell" aria-controls="powershell" aria-selected="false">Powershell</button>
+             <button class="tab-link" id="powershell-tab" data-bs-toggle="tab" data-bs-target="#powershell" aria-controls="powershell" aria-selected="false">
+               <i class="fab fa-windows me-2"></i>Powershell
+             </button>
            </li>
            <li class="nav-item">
-             <button class="tab-link" id="docker-tab" data-bs-toggle="tab" data-bs-target="#docker" aria-controls="docker" aria-selected="false">Docker</button>
+             <button class="tab-link" id="docker-tab" data-bs-toggle="tab" data-bs-target="#docker" aria-controls="docker" aria-selected="false">
+               <i class="fab fa-docker me-2"></i>Docker
+             </button>
            </li>
          </ul>
          
@@ -189,8 +201,39 @@
             <!-- Docker -->
             <div class="tab-pane fade" id="docker" aria-labelledby="docker-tab">
                <!-- Docker tab content -->
-               <p id="dockerConnectionHint" class="text-muted">Coming Soon.</p>
-               <pre id="tunnelCommandDocker" class="form-control" style="height: 400px" readonly></pre>
+               <div class="alert alert-info border-0 mb-3" style="background: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(16, 185, 129, 0.1)); border-radius: 12px;">
+                  <div class="d-flex align-items-start">
+                     <i class="fas fa-info-circle text-primary me-3 mt-1"></i>
+                     <div class="small">
+                        <strong>Docker Options:</strong> Choose between Docker Run (single command) or Docker Compose (service management). Both options automatically handle SSH key mounting and port mapping.
+                     </div>
+                  </div>
+               </div>
+               
+               <!-- Docker sub-tabs -->
+               <ul class="nav nav-tabs mb-3" id="dockerSubTab">
+                 <li class="nav-item">
+                   <button class="tab-link active" id="docker-run-tab" data-bs-toggle="tab" data-bs-target="#docker-run" aria-controls="docker-run" aria-selected="true">
+                     <i class="fas fa-play me-2"></i>Docker Run
+                   </button>
+                 </li>
+                 <li class="nav-item">
+                   <button class="tab-link" id="docker-compose-tab" data-bs-toggle="tab" data-bs-target="#docker-compose" aria-controls="docker-compose" aria-selected="false">
+                     <i class="fas fa-layer-group me-2"></i>Docker Compose
+                   </button>
+                 </li>
+               </ul>
+               
+               <div class="tab-content" id="dockerSubTabContent">
+                 <div class="tab-pane fade show active" id="docker-run" aria-labelledby="docker-run-tab">
+                   <p class="text-muted">Single Docker command to run AutoSSH in a container. Automatically handles SSH key mounting and port mapping.</p>
+                   <pre id="tunnelCommandDockerRun" class="form-control" style="height: 350px" readonly></pre>
+                 </div>
+                 <div class="tab-pane fade" id="docker-compose" aria-labelledby="docker-compose-tab">
+                   <p class="text-muted">Docker Compose configuration for managing AutoSSH as a service. Includes restart policies and environment variables.</p>
+                   <pre id="tunnelCommandDockerCompose" class="form-control" style="height: 350px" readonly></pre>
+                 </div>
+               </div>
             </div>
          </div>
        </div>

--- a/src/tunnels/templates/tunnels.html
+++ b/src/tunnels/templates/tunnels.html
@@ -110,7 +110,7 @@
    <div class="modal-dialog modal-dialog-scrollable modal-lg">
      <div class="modal-content">
        <div class="modal-header">
-         <h5 class="modal-title" id="serverScriptModalLabel">Reverse Server Tunnel Script</h5>
+         <h5 class="modal-title" id="serverScriptModalLabel">Reverse Server Tunnel Start Script</h5>
          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
        </div>
        <div class="modal-body">
@@ -120,13 +120,33 @@
             <input type="text" class="form-control" id="sshPort" placeholder="Enter SSH Port" value="22" data-toggle="tooltip" data-placement="right" title="Invalid Port Number">
          </div>
          
+         <!-- SSH Key Path -->
+         <div class="input-group mb-3">
+            <span class="input-group-text" id="basic-addon2">
+               <i class="fas fa-key me-2"></i>SSH Key Path (Optional)
+            </span>
+            <input type="text" class="form-control" id="sshKeyPathTunnels" placeholder="e.g., ~/.ssh/id_rsa" data-toggle="tooltip" data-placement="right" title="Specify custom SSH key location if needed">
+         </div>
+         
+         <div class="alert alert-info border-0 mb-3" style="background: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(16, 185, 129, 0.1)); border-radius: 12px;">
+            <div class="d-flex align-items-start">
+               <i class="fas fa-info-circle text-primary me-3 mt-1"></i>
+               <div class="small">
+                  <strong>Configuration Tips:</strong> Leave key path blank to use default SSH key (~/.ssh/id_rsa). Scripts will update automatically when you change these values.
+               </div>
+            </div>
+         </div>
+         
          <!-- Nav tabs -->
          <ul class="nav nav-tabs" id="osTab">
            <li class="nav-item">
-             <button class="tab-link active" id="ssh-tab" data-bs-toggle="tab" data-bs-target="#ssh" aria-controls="ssh" aria-selected="true">SSH</button>
+             <button class="tab-link active" id="ssh-simple-tab" data-bs-toggle="tab" data-bs-target="#ssh-simple" aria-controls="ssh-simple" aria-selected="true">SSH</button>
            </li>
            <li class="nav-item">
-            <button class="tab-link" id="ssh-service-tab" data-bs-toggle="tab" data-bs-target="#ssh-service" aria-controls="ssh-service" aria-selected="true">SSH Service</button>
+             <button class="tab-link" id="autossh-tab" data-bs-toggle="tab" data-bs-target="#autossh" aria-controls="autossh" aria-selected="false">AutoSSH</button>
+           </li>
+           <li class="nav-item">
+            <button class="tab-link" id="ssh-service-tab" data-bs-toggle="tab" data-bs-target="#ssh-service" aria-controls="ssh-service" aria-selected="false">SSH Service</button>
            </li>
            <li class="nav-item">
              <button class="tab-link" id="powershell-tab" data-bs-toggle="tab" data-bs-target="#powershell" aria-controls="powershell" aria-selected="false">Powershell</button>
@@ -138,16 +158,22 @@
          
          <!-- Tab content -->
          <div class="tab-content" id="osTabContent">
-            <!-- SSH -->
-            <div class="tab-pane fade show active" id="ssh" aria-labelledby="ssh-tab">
-               <!-- SSH tab content -->
-               <p class="text-muted">If you want to use private keys to login, you need to add public keys in <code>~/.ssh/authorized_keys</code> in your target server.</p>
-               <pre id="tunnelCommandSSH" class="form-control" style="height: 350px" readonly></pre>
+            <!-- SSH Simple -->
+            <div class="tab-pane fade show active" id="ssh-simple" aria-labelledby="ssh-simple-tab">
+               <!-- SSH Simple tab content -->
+               <p class="text-muted">Simple SSH tunnel connection. If you want to use private keys to login the remote server, you need to add public keys in <code>~/.ssh/authorized_keys</code> in your target server.</p>
+               <pre id="tunnelCommandSSHSimple" class="form-control" style="height: 350px" readonly></pre>
+            </div>
+            <!-- AutoSSH -->
+            <div class="tab-pane fade" id="autossh" aria-labelledby="autossh-tab">
+               <!-- AutoSSH tab content -->
+               <p class="text-muted">AutoSSH with automatic reconnection. If you want to use private keys to login the remote server, you need to add public keys in <code>~/.ssh/authorized_keys</code> in your target server.</p>
+               <pre id="tunnelCommandAutoSSH" class="form-control" style="height: 350px" readonly></pre>
             </div>
             <!-- SSH Service -->
             <div class="tab-pane fade" id="ssh-service" aria-labelledby="ssh-service-tab">
               <!-- SSH Service tab content -->
-              <p class="text-muted">If you want to use private keys to login, you need to add public keys in <code>~/.ssh/authorized_keys</code> in your target server.</p>
+              <p class="text-muted">If you want to use private keys to login the remote server, you need to add public keys in <code>~/.ssh/authorized_keys</code> in your target server.</p>
               <p class="text-muted alert-info">You can replace <code>User</code> field with your own username in the command.</p>
               <p class="text-muted">Paste the following script in <code>/etc/systemd/system/autossh.service</code> .</p>
               <pre id="tunnelCommandSSHService" class="form-control" style="height: 400px" readonly></pre>

--- a/src/tunnels/tunnel_script_renderer/__init__.py
+++ b/src/tunnels/tunnel_script_renderer/__init__.py
@@ -4,6 +4,7 @@ from .autossh_renderer import AutoSshTemplate
 from .autossh_service_renderer import AutoSshServiceTemplate
 from .ssh_renderer import SshTemplate
 from .ssh_config_renderer import SshClientTemplate, SshServerTemplate
+from .docker_renderer import DockerTemplate
 
 
 def ssh_tunnel_script_factory(
@@ -51,6 +52,26 @@ def ssh_tunnel_script_factory(
             reverse_server_ssh_port=reverse_server_ssh_port,
             username=username,
             key_path=key_path
+        )
+        return template
+    elif tunnel_type == "docker-run":
+        template = DockerTemplate.template_factory(
+            server_domain=server_domain,
+            reverse_port=reverse_port,
+            ssh_port=ssh_port,
+            reverse_server_ssh_port=reverse_server_ssh_port,
+            key_path=key_path,
+            docker_type="run"
+        )
+        return template
+    elif tunnel_type == "docker-compose":
+        template = DockerTemplate.template_factory(
+            server_domain=server_domain,
+            reverse_port=reverse_port,
+            ssh_port=ssh_port,
+            reverse_server_ssh_port=reverse_server_ssh_port,
+            key_path=key_path,
+            docker_type="compose"
         )
         return template
     else:

--- a/src/tunnels/tunnel_script_renderer/__init__.py
+++ b/src/tunnels/tunnel_script_renderer/__init__.py
@@ -2,6 +2,7 @@ from .template_renderer import BaseTemplateRenderer
 from .powershell_renderer import PowerShellTemplate
 from .autossh_renderer import AutoSshTemplate
 from .autossh_service_renderer import AutoSshServiceTemplate
+from .ssh_renderer import SshTemplate
 from .ssh_config_renderer import SshClientTemplate, SshServerTemplate
 
 
@@ -11,7 +12,8 @@ def ssh_tunnel_script_factory(
     reverse_port: int,
     ssh_port: int,
     reverse_server_ssh_port: int,
-    username:str="root") -> BaseTemplateRenderer:
+    username:str="root",
+    key_path: str=None) -> BaseTemplateRenderer:
     
     tunnel_type = tunnel_type.lower() # Normalize `tunnel_type`.
     if tunnel_type == "powershell":
@@ -19,7 +21,17 @@ def ssh_tunnel_script_factory(
             server_domain=server_domain,
             reverse_port=reverse_port,
             ssh_port=ssh_port,
-            reverse_server_ssh_port=reverse_server_ssh_port
+            reverse_server_ssh_port=reverse_server_ssh_port,
+            key_path=key_path
+        )
+        return template
+    elif tunnel_type == "ssh":
+        template = SshTemplate.template_factory(
+            server_domain=server_domain,
+            reverse_port=reverse_port,
+            ssh_port=ssh_port,
+            reverse_server_ssh_port=reverse_server_ssh_port,
+            key_path=key_path
         )
         return template
     elif tunnel_type == "autossh":
@@ -27,7 +39,8 @@ def ssh_tunnel_script_factory(
             server_domain=server_domain,
             reverse_port=reverse_port,
             ssh_port=ssh_port,
-            reverse_server_ssh_port=reverse_server_ssh_port
+            reverse_server_ssh_port=reverse_server_ssh_port,
+            key_path=key_path
         )
         return template
     elif tunnel_type == "autossh-service":
@@ -36,7 +49,8 @@ def ssh_tunnel_script_factory(
             reverse_port=reverse_port,
             ssh_port=ssh_port,
             reverse_server_ssh_port=reverse_server_ssh_port,
-            username=username
+            username=username,
+            key_path=key_path
         )
         return template
     else:

--- a/src/tunnels/tunnel_script_renderer/autossh_renderer.py
+++ b/src/tunnels/tunnel_script_renderer/autossh_renderer.py
@@ -8,18 +8,31 @@ TEMPLATE_DIR = Path(__file__).resolve().parent / Path("templates")
 
 class AutoSshTemplate(BaseTemplateRenderer):
 
-    def __init__(self, server_domain: str, reverse_port: int, ssh_port: int, reverse_server_ssh_port: int):
+    def __init__(self, server_domain: str, reverse_port: int, ssh_port: int, reverse_server_ssh_port: int, key_path: str = None):
 
         super().__init__(server_domain=server_domain, 
                          reverse_port=reverse_port, 
                          ssh_port=ssh_port, 
                          reverse_server_ssh_port=reverse_server_ssh_port)
+        
+        self.key_path = key_path
 
 
 
     @classmethod 
-    def template_factory(cls, server_domain: str, reverse_port: int, ssh_port: int, reverse_server_ssh_port: int) -> "AutoSshTemplate":
-        return cls(server_domain, reverse_port, ssh_port, reverse_server_ssh_port)
+    def template_factory(cls, server_domain: str, reverse_port: int, ssh_port: int, reverse_server_ssh_port: int, key_path: str = None) -> "AutoSshTemplate":
+        return cls(server_domain, reverse_port, ssh_port, reverse_server_ssh_port, key_path)
+    
+    def mapping_factory(self) -> dict:
+        mapping = super().mapping_factory()
+        
+        # Add key_path to mapping if provided
+        if self.key_path:
+            mapping["key_option"] = f" \\\n-i {self.key_path} "
+        else:
+            mapping["key_option"] = " "
+            
+        return mapping
     
     def render(self) -> str:
 

--- a/src/tunnels/tunnel_script_renderer/autossh_service_renderer.py
+++ b/src/tunnels/tunnel_script_renderer/autossh_service_renderer.py
@@ -15,6 +15,7 @@ class AutoSshServiceTemplate(BaseTemplateRenderer):
         ssh_port: int,
         reverse_server_ssh_port: int,
         username: str="root",
+        key_path: str=None,
     ) -> None:
 
         super().__init__(
@@ -24,11 +25,25 @@ class AutoSshServiceTemplate(BaseTemplateRenderer):
             reverse_server_ssh_port=reverse_server_ssh_port,
             username=username,
         )
+        
+        self.key_path = key_path
 
 
     @classmethod 
-    def template_factory(cls, server_domain: str, reverse_port: int, ssh_port: int, reverse_server_ssh_port: int, username:str) -> "AutoSshTemplate":
-        return cls(server_domain, reverse_port, ssh_port, reverse_server_ssh_port, username)
+    def template_factory(cls, server_domain: str, reverse_port: int, ssh_port: int, reverse_server_ssh_port: int, username:str, key_path: str=None) -> "AutoSshServiceTemplate":
+        return cls(server_domain, reverse_port, ssh_port, reverse_server_ssh_port, username, key_path)
+    
+    def mapping_factory(self) -> dict:
+        mapping = super().mapping_factory()
+        
+        # Add key_path to mapping if provided
+        # For service files, we don't want line breaks - keep everything on one line
+        if self.key_path:
+            mapping["key_option"] = f"-i {self.key_path} "
+        else:
+            mapping["key_option"] = ""
+            
+        return mapping
     
     def render(self) -> str:
 

--- a/src/tunnels/tunnel_script_renderer/docker_renderer.py
+++ b/src/tunnels/tunnel_script_renderer/docker_renderer.py
@@ -1,0 +1,66 @@
+from string import Template
+from pathlib import Path
+from .template_renderer import BaseTemplateRenderer
+
+# Absolute path of template directory path.
+# NOTE: change if the directory structure changed.
+TEMPLATE_DIR = Path(__file__).resolve().parent / Path("templates")
+
+class DockerTemplate(BaseTemplateRenderer):
+
+    def __init__(self, server_domain: str, reverse_port: int, ssh_port: int, reverse_server_ssh_port: int, key_path: str = None, docker_type: str = "run"):
+
+        super().__init__(server_domain=server_domain, 
+                         reverse_port=reverse_port, 
+                         ssh_port=ssh_port, 
+                         reverse_server_ssh_port=reverse_server_ssh_port)
+        
+        self.key_path = key_path
+        self.docker_type = docker_type
+
+    @classmethod 
+    def template_factory(cls, server_domain: str, reverse_port: int, ssh_port: int, reverse_server_ssh_port: int, key_path: str = None, docker_type: str = "run") -> "DockerTemplate":
+        return cls(server_domain, reverse_port, ssh_port, reverse_server_ssh_port, key_path, docker_type)
+    
+    def mapping_factory(self) -> dict:
+        mapping = super().mapping_factory()
+        
+        # Add key_path to mapping if provided
+        if self.key_path:
+            mapping["key_mount"] = f"  -v {self.key_path}:/root/.ssh/id_rsa:ro"
+            mapping["key_option"] = "  -i /root/.ssh/id_rsa"
+        else:
+            mapping["key_mount"] = ""
+            mapping["key_option"] = ""
+            
+        # Add docker type
+        mapping["docker_type"] = self.docker_type
+        
+        # Add Telepy public key (this should be the service key)
+        try:
+            from authorized_keys.models import ServiceAuthorizedKeys
+            service_key = ServiceAuthorizedKeys.objects.first()
+            if service_key:
+                mapping["telepy_public_key"] = service_key.key
+            else:
+                mapping["telepy_public_key"] = "# Telepy public key not found"
+        except:
+            mapping["telepy_public_key"] = "# Telepy public key not found"
+            
+        return mapping
+    
+    def render(self) -> str:
+        # Define mapping.
+        mapping = self.mapping_factory()
+
+        # Load template file based on docker type
+        if self.docker_type == "compose":
+            template_file = TEMPLATE_DIR / Path("docker_compose_template.yml")
+        else:  # docker run
+            template_file = TEMPLATE_DIR / Path("docker_run_template.sh")
+
+        # Render template.
+        template = Template(template_file.read_text())
+        rendered_template = template.safe_substitute(mapping)
+        
+        return rendered_template

--- a/src/tunnels/tunnel_script_renderer/powershell_renderer.py
+++ b/src/tunnels/tunnel_script_renderer/powershell_renderer.py
@@ -8,16 +8,29 @@ TEMPLATE_DIR = Path(__file__).resolve().parent / Path("templates")
 
 class PowerShellTemplate(BaseTemplateRenderer):
 
-    def __init__(self, server_domain: str, reverse_port: int, ssh_port: int, reverse_server_ssh_port: int):
+    def __init__(self, server_domain: str, reverse_port: int, ssh_port: int, reverse_server_ssh_port: int, key_path: str = None):
 
         super().__init__(server_domain=server_domain,
                         reverse_port=reverse_port,
                         ssh_port=ssh_port,
                         reverse_server_ssh_port=reverse_server_ssh_port)
+        
+        self.key_path = key_path
 
     @classmethod 
-    def template_factory(cls, server_domain: str, reverse_port: int, ssh_port: int, reverse_server_ssh_port: int) -> "PowerShellTemplate":
-        return cls(server_domain, reverse_port, ssh_port, reverse_server_ssh_port)
+    def template_factory(cls, server_domain: str, reverse_port: int, ssh_port: int, reverse_server_ssh_port: int, key_path: str = None) -> "PowerShellTemplate":
+        return cls(server_domain, reverse_port, ssh_port, reverse_server_ssh_port, key_path)
+    
+    def mapping_factory(self) -> dict:
+        mapping = super().mapping_factory()
+        
+        # Add key_path to mapping if provided (PowerShell style)
+        if self.key_path:
+            mapping["key_option"] = f"-i '{self.key_path}' "
+        else:
+            mapping["key_option"] = ""
+            
+        return mapping
     
     def render(self) -> str:
         # Define mapping.

--- a/src/tunnels/tunnel_script_renderer/ssh_renderer.py
+++ b/src/tunnels/tunnel_script_renderer/ssh_renderer.py
@@ -1,0 +1,48 @@
+from string import Template
+from pathlib import Path
+from .template_renderer import BaseTemplateRenderer
+
+# Absolute path of template directory path.
+# NOTE: change if the directory structure changed.
+TEMPLATE_DIR = Path(__file__).resolve().parent / Path("templates")
+
+class SshTemplate(BaseTemplateRenderer):
+
+    def __init__(self, server_domain: str, reverse_port: int, ssh_port: int, reverse_server_ssh_port: int, key_path: str = None):
+
+        super().__init__(server_domain=server_domain, 
+                         reverse_port=reverse_port, 
+                         ssh_port=ssh_port, 
+                         reverse_server_ssh_port=reverse_server_ssh_port)
+        
+        self.key_path = key_path
+
+
+    @classmethod 
+    def template_factory(cls, server_domain: str, reverse_port: int, ssh_port: int, reverse_server_ssh_port: int, key_path: str = None) -> "SshTemplate":
+        return cls(server_domain, reverse_port, ssh_port, reverse_server_ssh_port, key_path)
+    
+    def mapping_factory(self) -> dict:
+        mapping = super().mapping_factory()
+        
+        # Add key_path to mapping if provided
+        if self.key_path:
+            mapping["key_option"] = f" \\\n-i {self.key_path} "
+        else:
+            mapping["key_option"] = " "
+            
+        return mapping
+    
+    def render(self) -> str:
+
+        # Define mapping.
+        mapping = self.mapping_factory()
+
+        # Load template file.
+        template_file = TEMPLATE_DIR / Path("ssh_template.sh")
+
+        # Render template.
+        template = Template(template_file.read_text())
+        rendered_template = template.safe_substitute(mapping)
+        
+        return rendered_template

--- a/src/tunnels/tunnel_script_renderer/templates/autossh_template.service
+++ b/src/tunnels/tunnel_script_renderer/templates/autossh_template.service
@@ -6,7 +6,7 @@ After=network-online.target
 
 [Service]
 User=${username}
-ExecStart=/usr/bin/autossh -M 0 -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" -p ${reverse_server_ssh_port} -NR '*:${reverse_port}:localhost:${ssh_port}' telepy@${server_domain}
+ExecStart=/usr/bin/autossh -M 0 -o "ServerAliveInterval 30" -o "ServerAliveCountMax 3" -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" ${key_option}-p ${reverse_server_ssh_port} -NR '*:${reverse_port}:localhost:${ssh_port}' telepy@${server_domain}
 
 # Restart service after it exits
 Restart=always

--- a/src/tunnels/tunnel_script_renderer/templates/autossh_template.sh
+++ b/src/tunnels/tunnel_script_renderer/templates/autossh_template.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-echo "[+] Script start"
+echo "[+] AutoSSH Script start"
 
 autossh \
 -M 0 \
 -o "ServerAliveInterval 30" \
 -o "ServerAliveCountMax 3" \
 -o "StrictHostKeyChecking=no" \
--o "UserKnownHostsFile=/dev/null" \
+-o "UserKnownHostsFile=/dev/null" ${key_option}\
 -p ${reverse_server_ssh_port} \
 -NR '*:${reverse_port}:localhost:${ssh_port}' \
 telepy@${server_domain}

--- a/src/tunnels/tunnel_script_renderer/templates/docker_compose_template.yml
+++ b/src/tunnels/tunnel_script_renderer/templates/docker_compose_template.yml
@@ -1,0 +1,25 @@
+# Create authorized_keys file with Telepy public key
+# Run this command before starting the container:
+# mkdir -p ~/.ssh && echo "${telepy_public_key}" > ~/.ssh/authorized_keys
+
+services:
+  telepy-tunnel:
+    image: alpine/autossh:latest
+    container_name: telepy-tunnel
+    restart: unless-stopped
+    ports:
+      - "${reverse_port}:${reverse_port}"
+    volumes:${key_mount}
+    command: >
+      autossh
+      -M 0
+      -o "ServerAliveInterval 30"
+      -o "ServerAliveCountMax 3"
+      -o "StrictHostKeyChecking=no"
+      -o "UserKnownHostsFile=/dev/null"${key_option}
+      -p ${reverse_server_ssh_port}
+      -NR '*:${reverse_port}:localhost:${ssh_port}'
+      telepy@${server_domain}
+    environment:
+      - AUTOSSH_GATETIME=0
+      - AUTOSSH_PORT=0

--- a/src/tunnels/tunnel_script_renderer/templates/docker_run_template.sh
+++ b/src/tunnels/tunnel_script_renderer/templates/docker_run_template.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+echo "[+] Docker AutoSSH Script start"
+
+# Create authorized_keys file with Telepy public key
+mkdir -p ~/.ssh
+cat > ~/.ssh/authorized_keys << 'EOF'
+${telepy_public_key}
+EOF
+
+# Run AutoSSH in Docker container
+docker run -d \
+  --name telepy-tunnel \
+  --restart unless-stopped \
+  -p ${reverse_port}:${reverse_port}${key_mount} \
+  alpine/autossh:latest \
+  autossh \
+  -M 0 \
+  -o "ServerAliveInterval 30" \
+  -o "ServerAliveCountMax 3" \
+  -o "StrictHostKeyChecking=no" \
+  -o "UserKnownHostsFile=/dev/null"${key_option} \
+  -p ${reverse_server_ssh_port} \
+  -NR '*:${reverse_port}:localhost:${ssh_port}' \
+  telepy@${server_domain}
+
+echo "[+] Docker container started. Check logs with: docker logs telepy-tunnel"

--- a/src/tunnels/tunnel_script_renderer/templates/powershell_template.ps1
+++ b/src/tunnels/tunnel_script_renderer/templates/powershell_template.ps1
@@ -1,6 +1,6 @@
 # PowerShell script
 
-echo "[+] Script start"
+echo "[+] SSH Script start"
 
 ### Configuration
 
@@ -13,7 +13,7 @@ $sshRemoteForward = "*:${reverse_port}:localhost:${ssh_port}"
 # The {reverse_server_ssh_port} is a placeholder for template rendering.
 $reverseServerSSHPort = "${reverse_server_ssh_port}"
 
-$sshOptions = "-o ServerAliveInterval=15 -o ServerAliveCountMax=3 -o StrictHostKeyChecking=no"
+$sshOptions = "${key_option}-o ServerAliveInterval=15 -o ServerAliveCountMax=3 -o StrictHostKeyChecking=no"
 $sshCommand = "ssh $sshOptions -p $reverseServerSSHPort -NR $sshRemoteForward $sshUserHost"
 
 # Add-Type for PowerManagement to prevent sleep

--- a/src/tunnels/tunnel_script_renderer/templates/ssh_template.sh
+++ b/src/tunnels/tunnel_script_renderer/templates/ssh_template.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "[+] SSH Tunnel Script start"
+
+ssh ${key_option}\
+-o "ServerAliveInterval 30" \
+-o "ServerAliveCountMax 3" \
+-o "StrictHostKeyChecking=no" \
+-o "UserKnownHostsFile=/dev/null" \
+-p ${reverse_server_ssh_port} \
+-NR '*:${reverse_port}:localhost:${ssh_port}' \
+telepy@${server_domain}

--- a/src/tunnels/urls.py
+++ b/src/tunnels/urls.py
@@ -7,6 +7,7 @@ from tunnels.views import AdminSettings
 from tunnels.views import SSHServerLogs
 from tunnels.views import ReverseServerAuthorizedKeysConfig
 from tunnels.views import PowershellSSHTunnelScript
+from tunnels.views import SSHTunnelScript
 from tunnels.views import AutoSSHTunnelScript
 from tunnels.views import AutoSSHServiceTunnelScript
 urlpatterns = [
@@ -20,6 +21,7 @@ urlpatterns = [
 
     path('server/config/<int:server_id>', ReverseServerAuthorizedKeysConfig.as_view(), name='authorized-keys-config'),
     path('server/script/powershell/<int:server_id>/<int:ssh_port>', PowershellSSHTunnelScript.as_view(), name='powershell-ssh-tunnel-script'),
+    path('server/script/ssh/<int:server_id>/<int:ssh_port>', SSHTunnelScript.as_view(), name='ssh-tunnel-script'),
     path('server/script/autossh/<int:server_id>/<int:ssh_port>', AutoSSHTunnelScript.as_view(), name='auto-ssh-tunnel-script'),
     path('server/script/autossh-service/<int:server_id>/<int:ssh_port>', AutoSSHServiceTunnelScript.as_view(), name='auto-ssh-service-tunnel-script'),
 

--- a/src/tunnels/urls.py
+++ b/src/tunnels/urls.py
@@ -10,6 +10,8 @@ from tunnels.views import PowershellSSHTunnelScript
 from tunnels.views import SSHTunnelScript
 from tunnels.views import AutoSSHTunnelScript
 from tunnels.views import AutoSSHServiceTunnelScript
+from tunnels.views import DockerRunTunnelScript
+from tunnels.views import DockerComposeTunnelScript
 urlpatterns = [
 
     path('index', TunnelsIndex.as_view(), name='tunnels-index'),
@@ -24,6 +26,8 @@ urlpatterns = [
     path('server/script/ssh/<int:server_id>/<int:ssh_port>', SSHTunnelScript.as_view(), name='ssh-tunnel-script'),
     path('server/script/autossh/<int:server_id>/<int:ssh_port>', AutoSSHTunnelScript.as_view(), name='auto-ssh-tunnel-script'),
     path('server/script/autossh-service/<int:server_id>/<int:ssh_port>', AutoSSHServiceTunnelScript.as_view(), name='auto-ssh-service-tunnel-script'),
+    path('server/script/docker-run/<int:server_id>/<int:ssh_port>', DockerRunTunnelScript.as_view(), name='docker-run-tunnel-script'),
+    path('server/script/docker-compose/<int:server_id>/<int:ssh_port>', DockerComposeTunnelScript.as_view(), name='docker-compose-tunnel-script'),
 
 ]
 

--- a/src/tunnels/views.py
+++ b/src/tunnels/views.py
@@ -232,18 +232,62 @@ class PowershellSSHTunnelScript(ReverseServerScriptBase):
         ssh_port: int
     ):
         reverse_port = server_auth_key.reverse_port
+        
+        # Get optional key_path from query parameters
+        key_path = self.request.GET.get('key_path', None)
+        if key_path:
+            key_path = key_path.strip()
+            if not key_path:  # Empty string after strip
+                key_path = None
 
         config_string = ssh_tunnel_script_factory(
           "powershell", 
           server_domain=self.server_domain, 
           reverse_port=reverse_port, 
           ssh_port=ssh_port, 
-          reverse_server_ssh_port=self.reverse_server_ssh_port
+          reverse_server_ssh_port=self.reverse_server_ssh_port,
+          key_path=key_path
         ).render()
 
         return Response({
             "script": config_string,
             "language": "powershell",
+        })
+
+
+class SSHTunnelScript(ReverseServerScriptBase):
+    script_type = ScriptType.SCRIPT
+    @swagger_auto_schema(
+        operation_summary="SSH Tunnel Script",
+        operation_description="SSH Tunnel Script",
+        tags=['Script']
+    )
+    def get_script(
+        self,
+        server_auth_key: ReverseServerAuthorizedKeys,
+        ssh_port: int
+    ):
+        reverse_port = server_auth_key.reverse_port
+        
+        # Get optional key_path from query parameters
+        key_path = self.request.GET.get('key_path', None)
+        if key_path:
+            key_path = key_path.strip()
+            if not key_path:  # Empty string after strip
+                key_path = None
+        
+        config_string = ssh_tunnel_script_factory(
+          "ssh", 
+          server_domain=self.server_domain, 
+          reverse_port=reverse_port, 
+          ssh_port=ssh_port, 
+          reverse_server_ssh_port=self.reverse_server_ssh_port,
+          key_path=key_path
+        ).render()
+
+        return Response({
+            "script": config_string,
+            "language": "bash",
         })
 
 
@@ -260,12 +304,21 @@ class AutoSSHTunnelScript(ReverseServerScriptBase):
         ssh_port: int
     ):
         reverse_port = server_auth_key.reverse_port
+        
+        # Get optional key_path from query parameters
+        key_path = self.request.GET.get('key_path', None)
+        if key_path:
+            key_path = key_path.strip()
+            if not key_path:  # Empty string after strip
+                key_path = None
+        
         config_string = ssh_tunnel_script_factory(
           "autossh", 
           server_domain=self.server_domain, 
           reverse_port=reverse_port, 
           ssh_port=ssh_port, 
-          reverse_server_ssh_port=self.reverse_server_ssh_port
+          reverse_server_ssh_port=self.reverse_server_ssh_port,
+          key_path=key_path
         ).render()
 
         return Response({
@@ -293,13 +346,21 @@ class AutoSSHServiceTunnelScript(ReverseServerScriptBase):
         except AttributeError:
             return Response({'error': 'No username found for this server'}, status=404)
 
+        # Get optional key_path from query parameters
+        key_path = self.request.GET.get('key_path', None)
+        if key_path:
+            key_path = key_path.strip()
+            if not key_path:  # Empty string after strip
+                key_path = None
+
         config_string = ssh_tunnel_script_factory(
           "autossh-service", 
           server_domain=self.server_domain, 
           reverse_port=reverse_port, 
           ssh_port=ssh_port, 
           reverse_server_ssh_port=self.reverse_server_ssh_port,
-          username=username
+          username=username,
+          key_path=key_path
         ).render()
 
         return Response({

--- a/src/tunnels/views.py
+++ b/src/tunnels/views.py
@@ -368,3 +368,75 @@ class AutoSSHServiceTunnelScript(ReverseServerScriptBase):
             "language": "bash",
         })
 
+
+class DockerRunTunnelScript(ReverseServerScriptBase):
+    script_type = ScriptType.SCRIPT
+    @swagger_auto_schema(
+        operation_summary="Docker Run Tunnel Script",
+        operation_description="Docker Run Tunnel Script",
+        tags=['Script']
+    )
+    def get_script(
+        self,
+        server_auth_key: ReverseServerAuthorizedKeys,
+        ssh_port: int
+    ):
+        reverse_port = server_auth_key.reverse_port
+        
+        # Get optional key_path from query parameters
+        key_path = self.request.GET.get('key_path', None)
+        if key_path:
+            key_path = key_path.strip()
+            if not key_path:  # Empty string after strip
+                key_path = None
+        
+        config_string = ssh_tunnel_script_factory(
+          "docker-run", 
+          server_domain=self.server_domain, 
+          reverse_port=reverse_port, 
+          ssh_port=ssh_port, 
+          reverse_server_ssh_port=self.reverse_server_ssh_port,
+          key_path=key_path
+        ).render()
+
+        return Response({
+            "script": config_string,
+            "language": "bash",
+        })
+
+
+class DockerComposeTunnelScript(ReverseServerScriptBase):
+    script_type = ScriptType.SCRIPT
+    @swagger_auto_schema(
+        operation_summary="Docker Compose Tunnel Script",
+        operation_description="Docker Compose Tunnel Script",
+        tags=['Script']
+    )
+    def get_script(
+        self,
+        server_auth_key: ReverseServerAuthorizedKeys,
+        ssh_port: int
+    ):
+        reverse_port = server_auth_key.reverse_port
+        
+        # Get optional key_path from query parameters
+        key_path = self.request.GET.get('key_path', None)
+        if key_path:
+            key_path = key_path.strip()
+            if not key_path:  # Empty string after strip
+                key_path = None
+        
+        config_string = ssh_tunnel_script_factory(
+          "docker-compose", 
+          server_domain=self.server_domain, 
+          reverse_port=reverse_port, 
+          ssh_port=ssh_port, 
+          reverse_server_ssh_port=self.reverse_server_ssh_port,
+          key_path=key_path
+        ).render()
+
+        return Response({
+            "script": config_string,
+            "language": "yaml",
+        })
+


### PR DESCRIPTION
這次PR主要目的為改善通道建立的流程體驗，包含以下內容：

1. 輸入金鑰部分加註`target server`來讓使用者理解目前要添加的金鑰是哪個地方的
<img width="641" height="219" alt="image" src="https://github.com/user-attachments/assets/8cfdbc5c-4894-48d3-9a35-cce19c6f20b8" />

2. 將多餘的混淆按鈕拿掉（例如建立通道第三步的create user按鈕多了一個）
<img width="805" height="546" alt="image" src="https://github.com/user-attachments/assets/2dfde066-d890-4877-96ff-37462c8c320f" />

3. 建立通道第四步將embed console改為更簡單的燈號顯示，並且在後端新建一個websocket接口，專門讓使用者在新增通道的時候驗證通道連線狀態4. 建立通道第四步將embed console改為更簡單的燈號顯示，並且在後端新建一個websocket接口，專門讓使用者在新增通道的時候驗證通道連線狀態
<img width="641" height="274" alt="image" src="https://github.com/user-attachments/assets/4ba73eeb-1b82-4642-8051-3b775991c652" />

4. 建立通道第四步多一個SSH的腳本選項，讓使用者在沒有安裝autossh的狀況下可以使用（或是單純測試用）5. 建立通道第四步多一個SSH的腳本選項，讓使用者在沒有安裝autossh的狀況下可以使用（或是單純測試用）
<img width="644" height="326" alt="image" src="https://github.com/user-attachments/assets/c8745cb3-6648-4a03-8d4d-2dc5d69f04df" />

5. 首頁tunnels列表中，script的部分新增docker分頁，裡面有docker跟docker compose的子分頁，內容是提供使用者新的腳本（不同方式）來建立連接telepy的通道，後端的部分也新增docker及docker-compose的render腳本6. 首頁tunnels列表中，script的部分新增docker分頁，裡面有docker跟docker compose的子分頁，內容是提供使用者新的腳本（不同方式）來建立連接telepy的通道，後端的部分也新增docker及docker-compose的render腳本
<img width="615" height="619" alt="image" src="https://github.com/user-attachments/assets/fcad6898-d89d-40a9-8b29-ba6f30a6026a" />
